### PR TITLE
Rename to NervesHubLinK

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,1 +1,1 @@
-alias NervesHubDevice.FirmwareChannel
+alias NervesHubLink.FirmwareChannel

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NervesHub
 
-[![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_device/tree/master.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_device/tree/master)
-[![Hex version](https://img.shields.io/hexpm/v/nerves_hub_device.svg "Hex version")](https://hex.pm/packages/nerves_hub_device)
+[![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_link/tree/master.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_link/tree/master)
+[![Hex version](https://img.shields.io/hexpm/v/nerves_hub_link.svg "Hex version")](https://hex.pm/packages/nerves_hub_link)
 
 This is the official client for devices that want to receive firmware updates from NervesHub.
 
@@ -13,7 +13,7 @@ Nerves-based devices. A managed version is available at
 
 NervesHub provides many of the features that you'd expect in a firmware update
 server. Fundamentally, devices connect to the server by joining a long-lived Phoenix
-channel (for HTTP polling, see [nerves_hub_device_http](https://github.com/nerves-hub/nerves_hub_device_http)).
+channel (for HTTP polling, see [nerves_hub_link_http](https://github.com/nerves-hub/nerves_hub_link_http)).
 If a firmware update is available, NervesHub will provide a URL to the device and the
 device can update immediately or [when convenient](https://github.com/nerves-hub/nerves_hub#conditionally-applying-updates).
 
@@ -74,9 +74,9 @@ If you already have an account, make sure that you have authenticated by running
 mix nerves_hub.user auth
 ```
 
-### Adding NervesHubDevice to your project
+### Adding NervesHubLink to your project
 
-The first step is to add `nerves_hub_device` to your target dependencies in your
+The first step is to add `nerves_hub_link` to your target dependencies in your
 project's `mix.exs`. Since NervesHub uses SSL certificates, the time must be set
 on the device or certificate validity checks will fail. If you're not already
 setting the time, add [`nerves_time`](https://hex.pm/packages/nerves_time) to
@@ -93,24 +93,24 @@ your dependencies. For example:
   end
 ```
 
-Next, update your `config.exs` so that the `nerves_hub_device` library can help
-provision devices. Do this by adding `provisioning: :nerves_hub_device` to the
+Next, update your `config.exs` so that the `nerves_hub_link` library can help
+provision devices. Do this by adding `provisioning: :nerves_hub_link` to the
 `:nerves, :firmware` option like this:
 
 ```elixir
 config :nerves, :firmware,
-  provisioning: :nerves_hub_device
+  provisioning: :nerves_hub_link
 ```
 
 The library won't connect to [nerves-hub.org](https://nerves-hub.org) unless
 requested and SSL options must be configured. 
 
 If using [NervesKey](https://github.com/nerves-hub/nerves_key), you can tell
-`NervesHubDevice` to read those certificates and key from the chip and assign
+`NervesHubLink` to read those certificates and key from the chip and assign
 the SSL options for you by enabling it:
 
 ```elixir
-config :nerves_hub_device, :nerves_key,
+config :nerves_hub_link, :nerves_key,
   enabled: true
 ```
 
@@ -119,7 +119,7 @@ cerificate pair. However, you can cusomtize these options as well to use
 a different bus and certificate pair:
 
 ```elixir
-config :nerves_hub_device, :nerves_key,
+config :nerves_hub_link, :nerves_key,
   enabled: true,
   certificate_pair: :aux,
   i2c_bus: 0
@@ -130,7 +130,7 @@ to use for the NervesHub socket connection via the `socket` key in the
 config using [valid Erlang ssl socket options](http://erlang.org/doc/man/ssl.html#TLS/DTLS%20OPTION%20DESCRIPTIONS%20-%20COMMON%20for%20SERVER%20and%20CLIENT)
 
 ```elixir
-config :nerves_hub_device, :socket,
+config :nerves_hub_link, :socket,
   cert: "some_cert_der",
   keyfile: "path/to/keyfile"
 ```
@@ -200,7 +200,7 @@ that are stored locally (like the one we just created) can be referred to by
 their atom name:
 
 ```elixir
-config :nerves_hub_device,
+config :nerves_hub_link,
   fwup_public_keys: [:devkey]
 ```
 
@@ -208,20 +208,20 @@ If you have keys that cannot be stored locally, you will have to copy/paste
 their public key:
 
 ```elixir
-config :nerves_hub_device,
+config :nerves_hub_link,
   fwup_public_keys: [
     # devkey
     "bM/O9+ykZhCWx8uZVgx0sU3f0JJX7mqnAVU9VGeuHr4="
   ]
 ```
 
-The `nerves_hub_device` dependency converts key names to public keys at compile time.
+The `nerves_hub_link` dependency converts key names to public keys at compile time.
 If you haven't compiled your project yet, run `mix firmware` now. If you have
-compiled it, `mix` won't know to recompile `nerves_hub_device` due to the configuration
+compiled it, `mix` won't know to recompile `nerves_hub_link` due to the configuration
 change. Force it to recompile by running:
 
 ```bash
-mix deps.compile nerves_hub_device --force
+mix deps.compile nerves_hub_link --force
 mix firmware
 ```
 
@@ -351,20 +351,20 @@ mix nerves_hub.firmware publish --key devkey --deploy qa_deployment
 ### Conditionally applying updates
 
 It's not always appropriate to apply a firmware update immediately.
-Custom logic can be added to the device by implementing the `NervesHubDevice.Client` behaviour and telling the NervesHubDevice OTP application about it.
+Custom logic can be added to the device by implementing the `NervesHubLink.Client` behaviour and telling the NervesHubLink OTP application about it.
 
 Here's an example implementation:
 
 ```elixir
-defmodule MyApp.NervesHubDeviceClient do
-   @behaviour NervesHubDevice.Client
+defmodule MyApp.NervesHubLinkClient do
+   @behaviour NervesHubLink.Client
 
    # May return:
    #  * `:apply` - apply the action immediately
    #  * `:ignore` - don't apply the action, don't ask again.
    #  * `{:reschedule, timeout_in_milliseconds}` - call this function again later.
 
-   @impl NervesHubDevice.Client
+   @impl NervesHubLink.Client
    def update_available(data) do
     if SomeInternalAPI.is_now_a_good_time_to_update?(data) do
       :apply
@@ -375,10 +375,10 @@ defmodule MyApp.NervesHubDeviceClient do
 end
 ```
 
-To have NervesHubDevice invoke it, update your `config.exs` as follows:
+To have NervesHubLink invoke it, update your `config.exs` as follows:
 
 ```elixir
-config :nerves_hub_device, client: MyApp.NervesHubDeviceClient
+config :nerves_hub_link, client: MyApp.NervesHubLinkClient
 ```
 
 ### Enabling remote IEx access
@@ -387,7 +387,7 @@ It's possible to remotely log into your device via the NervesHub web interface. 
 feature is disabled by default. To enable, add the following to your `config.exs`:
 
 ```elixir
-config :nerves_hub_device, remote_iex: true
+config :nerves_hub_link, remote_iex: true
 ```
 
 You may also need additional permissions on NervesHub to see the device and to use the

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-# This config.exs file will configure `nerves_hub_device` to point to a local instance
+# This config.exs file will configure `nerves_hub_link` to point to a local instance
 # of `nerves_hub_web`. See CONTRIBUTING.md for details.
 
 import_config("#{Mix.env()}.exs")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,7 @@ config :nerves_hub_cli,
   ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__)
 
 # Shared Configuration.
-config :nerves_hub_device,
+config :nerves_hub_link,
   ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__)
 
 # API HTTP connection.
@@ -14,7 +14,7 @@ config :nerves_hub_user_api,
   port: 4002
 
 # Device HTTP connection.
-config :nerves_hub_device,
+config :nerves_hub_link,
   device_api_host: "0.0.0.0",
   device_api_port: 4001
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,7 +5,7 @@ config :nerves_hub_cli,
   ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__)
 
 # Shared Configuration.
-config :nerves_hub_device,
+config :nerves_hub_link,
   ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__)
 
 # API HTTP connection.
@@ -14,12 +14,12 @@ config :nerves_hub_user_api,
   port: 4002
 
 # Device HTTP connection.
-config :nerves_hub_device,
+config :nerves_hub_link,
   device_api_host: "0.0.0.0",
   device_api_port: 4001
 
-config :nerves_hub_device,
-  client: NervesHubDevice.ClientMock,
+config :nerves_hub_link,
+  client: NervesHubLink.ClientMock,
   rejoin_after: 0
 
 config :nerves_runtime, :kernel, autoload_modules: false

--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -9,7 +9,7 @@ use Mix.Config
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.
 config :nerves, :firmware,
   rootfs_overlay: "rootfs_overlay",
-  provisioning: :nerves_hub_device
+  provisioning: :nerves_hub_link
 
 config :logger,
   backends: [RingLogger]
@@ -33,7 +33,7 @@ config :nerves_firmware_ssh,
     File.read!(Path.join(System.user_home!(), ".ssh/id_rsa.pub"))
   ]
 
-config :nerves_hub_device,
+config :nerves_hub_link,
   fwup_public_keys: [:test]
 
 ## Uncomment for local NervesHubWeb development
@@ -46,10 +46,10 @@ config :nerves_hub_user_api,
 #   home: Path.expand("../.nerves-hub"),
 #   ca_certs: Path.expand("../test/fixtures/ca_certs")
 
-# config :nerves_hub_device, NervesHubDevice.Socket,
+# config :nerves_hub_link, NervesHubLink.Socket,
 #   url: "wss://nerves-hub.org:4001/socket/websocket"
 
-# config :nerves_hub_device,
+# config :nerves_hub_link,
 #   ca_certs: "/etc/ssl_dev"
 
 ## Uncomment for connecting over WIFI

--- a/example/lib/example/application.ex
+++ b/example/lib/example/application.ex
@@ -11,7 +11,7 @@ defmodule Example.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     children = [
-      NervesHubDevice.Supervisor
+      NervesHubLink.Supervisor
     ] ++ children(@target)
 
     opts = [strategy: :one_for_one, name: Example.Supervisor]

--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubDevice do
+defmodule NervesHubLink do
   @doc """
   Checks if the device is connected to the NervesHub channel.
   """
@@ -11,14 +11,14 @@ defmodule NervesHubDevice do
   @doc """
   Current status of the device channel
   """
-  @spec status :: NervesHubDevice.Channel.State.status()
+  @spec status :: NervesHubLink.Channel.State.status()
   def status() do
     channel_state()
     |> Map.get(:status, :unknown)
   end
 
   defp channel_state() do
-    GenServer.whereis(NervesHubDevice.Channel)
+    GenServer.whereis(NervesHubLink.Channel)
     |> case do
       channel when is_pid(channel) -> GenServer.call(channel, :get_state)
       _ -> %{}

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -1,7 +1,7 @@
-defmodule NervesHubDevice.Application do
+defmodule NervesHubLink.Application do
   use Application
 
-  alias NervesHubDevice.{Channel, Connection, ConsoleChannel, Socket}
+  alias NervesHubLink.{Channel, Connection, ConsoleChannel, Socket}
 
   def start(_type, _args) do
     params = Nerves.Runtime.KV.get_all_active()
@@ -14,11 +14,11 @@ defmodule NervesHubDevice.Application do
       ]
       |> add_console_child(params)
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: NervesHubDevice.Supervisor)
+    Supervisor.start_link(children, strategy: :one_for_one, name: NervesHubLink.Supervisor)
   end
 
   defp add_console_child(children, params) do
-    if Application.get_env(:nerves_hub_device, :remote_iex, false) do
+    if Application.get_env(:nerves_hub_link, :remote_iex, false) do
       [{ConsoleChannel, [socket: Socket, params: params]} | children]
     else
       children

--- a/lib/nerves_hub_link/certificate.ex
+++ b/lib/nerves_hub_link/certificate.ex
@@ -1,16 +1,16 @@
-defmodule NervesHubDevice.Certificate do
+defmodule NervesHubLink.Certificate do
   # Get the fwup public keys from the app environment.
   # For now, this first requires adding a key to the environment that
   # the resolver depends on until https://github.com/nerves-hub/nerves_hub_cli/pull/125
   # is merged and released
-  Application.put_env(:nerves_hub, :org, Application.get_env(:nerves_hub_device, :org))
+  Application.put_env(:nerves_hub, :org, Application.get_env(:nerves_hub_link, :org))
 
-  @public_keys Application.get_env(:nerves_hub_device, :fwup_public_keys, [])
+  @public_keys Application.get_env(:nerves_hub_link, :fwup_public_keys, [])
                |> NervesHubCLI.resolve_fwup_public_keys()
 
   ca_cert_path =
-    System.get_env("NERVES_HUB_CA_CERTS") || Application.get_env(:nerves_hub_device, :ca_certs) ||
-      Application.app_dir(:nerves_hub_device, ["priv", "ca_certs"])
+    System.get_env("NERVES_HUB_CA_CERTS") || Application.get_env(:nerves_hub_link, :ca_certs) ||
+      Application.app_dir(:nerves_hub_link, ["priv", "ca_certs"])
 
   ca_certs =
     ca_cert_path

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -1,24 +1,24 @@
-defmodule NervesHubDevice.Client do
+defmodule NervesHubLink.Client do
   @moduledoc """
   A behaviour module for customizing if and when firmware updates get applied.
 
-  By default NervesHubDevice applies updates as soon as it knows about them from the
-  NervesHubDevice server and doesn't give warning before rebooting. This let's
+  By default NervesHubLink applies updates as soon as it knows about them from the
+  NervesHubLink server and doesn't give warning before rebooting. This let's
   devices hook into the decision making process and monitor the update's
   progress.
 
   # Example
 
   ```elixir
-  defmodule MyApp.NervesHubDeviceClient do
-    @behaviour NervesHubDevice.Client
+  defmodule MyApp.NervesHubLinkClient do
+    @behaviour NervesHubLink.Client
 
     # May return:
     #  * `:apply` - apply the action immediately
     #  * `:ignore` - don't apply the action, don't ask again.
     #  * `{:reschedule, timeout_in_milliseconds}` - call this function again later.
 
-    @impl NervesHubDevice.Client
+    @impl NervesHubLink.Client
     def update_available(data) do
       if SomeInternalAPI.is_now_a_good_time_to_update?(data) do
         :apply
@@ -29,10 +29,10 @@ defmodule NervesHubDevice.Client do
   end
   ```
 
-  To have NervesHubDevice invoke it, add the following to your `config.exs`:
+  To have NervesHubLink invoke it, add the following to your `config.exs`:
 
   ```elixir
-  config :nerves_hub, client: MyApp.NervesHubDeviceClient
+  config :nerves_hub, client: MyApp.NervesHubLinkClient
   ```
   """
 
@@ -77,7 +77,7 @@ defmodule NervesHubDevice.Client do
   @callback handle_error(any()) :: :ok
 
   @doc """
-  This function is called internally by NervesHubDevice to notify clients.
+  This function is called internally by NervesHubLink to notify clients.
   """
   @spec update_available(module(), update_data()) :: update_response()
   def update_available(client, data) do
@@ -93,7 +93,7 @@ defmodule NervesHubDevice.Client do
 
       wrong ->
         Logger.error(
-          "[NervesHubDevice] Client: #{client}.update_available/1 bad return value: #{
+          "[NervesHubLink] Client: #{client}.update_available/1 bad return value: #{
             inspect(wrong)
           } Applying update."
         )
@@ -103,7 +103,7 @@ defmodule NervesHubDevice.Client do
   end
 
   @doc """
-  This function is called internally by NervesHubDevice to notify clients of fwup progress.
+  This function is called internally by NervesHubLink to notify clients of fwup progress.
   """
   @spec handle_fwup_message(module(), fwup_message()) :: :ok
   def handle_fwup_message(client, data) do
@@ -112,7 +112,7 @@ defmodule NervesHubDevice.Client do
   end
 
   @doc """
-  This function is called internally by NervesHubDevice to notify clients of fwup errors.
+  This function is called internally by NervesHubLink to notify clients of fwup errors.
   """
   @spec handle_error(module(), any()) :: :ok
   def handle_error(client, data) do

--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -1,17 +1,17 @@
-defmodule NervesHubDevice.Client.Default do
+defmodule NervesHubLink.Client.Default do
   @moduledoc """
-  Default NervesHubDevice.Client implementation
+  Default NervesHubLink.Client implementation
 
   This client always accepts an update.
   """
 
-  @behaviour NervesHubDevice.Client
+  @behaviour NervesHubLink.Client
   require Logger
 
-  @impl NervesHubDevice.Client
+  @impl NervesHubLink.Client
   def update_available(_), do: :apply
 
-  @impl NervesHubDevice.Client
+  @impl NervesHubLink.Client
   def handle_fwup_message({:progress, percent}) when rem(percent, 25) == 0 do
     Logger.debug("FWUP PROG: #{percent}%")
   end
@@ -28,7 +28,7 @@ defmodule NervesHubDevice.Client.Default do
     Logger.warn("Unknown FWUP message: #{inspect(fwup_message)}")
   end
 
-  @impl NervesHubDevice.Client
+  @impl NervesHubLink.Client
   def handle_error(error) do
     Logger.warn("Firmware stream error: #{inspect(error)}")
   end

--- a/lib/nerves_hub_link/connection.ex
+++ b/lib/nerves_hub_link/connection.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubDevice.Connection do
+defmodule NervesHubLink.Connection do
   @moduledoc """
   Agent used to keep the simple state of the devices connection
   to [nerves-hub.org](https://www.nerves-hub.org).
@@ -19,14 +19,14 @@ defmodule NervesHubDevice.Connection do
   ```
   # Set a callback for heart to check every 5 seconds. If the function returns anything other than
   # `:ok`, it will cause reboot.
-  :heart.set_callback(NervesHubDevice.Connection, :check!)
+  :heart.set_callback(NervesHubLink.Connection, :check!)
   ```
 
   Or, you can use the check as part of a separate function with other health checks as well
   ```
   defmodule MyApp.Checker do
     def health_check do
-      with :ok <- NervesHubDevice.Connection.check,
+      with :ok <- NervesHubLink.Connection.check,
            :ok <- MyApp.another_check,
            :ok <- MyApp.yet_another_check,
       do
@@ -84,7 +84,7 @@ defmodule NervesHubDevice.Connection do
   @spec check!() :: :ok
   def check!() do
     unless check() == :ok do
-      raise "too much time has passed since a successful connection to NervesHubDevice"
+      raise "too much time has passed since a successful connection to NervesHubLink"
     end
 
     :ok

--- a/lib/nerves_hub_link/console_channel.ex
+++ b/lib/nerves_hub_link/console_channel.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubDevice.ConsoleChannel do
+defmodule NervesHubLink.ConsoleChannel do
   use GenServer
   require Logger
 
@@ -9,7 +9,7 @@ defmodule NervesHubDevice.ConsoleChannel do
   The remote console ability is disabled by default and requires the
   `remote_iex` key to be enabled in the config:
   ```
-  config :nerves_hub_device, remote_iex: true
+  config :nerves_hub_link, remote_iex: true
   ```
 
   Once connected, IO requests on the device will be pushed up the socket
@@ -19,7 +19,7 @@ defmodule NervesHubDevice.ConsoleChannel do
   Typically just `iex () >`
   * `put_chars` - Display the sepcified characters from the IEx Server for user review
     * This requires an immediate reply of `:ok` and then IEx will send a `:get_line`
-    request to await the user input. NervesHubDeviceWeb handles immediately replies `:ok`
+    request to await the user input. NervesHubLinkWeb handles immediately replies `:ok`
     to these events (see below)
   * `init_attempt` - Pushed asynchronously after attempting to init an IEx Server.
   Payload has a `success` key with a boolean value to specify whether the server
@@ -39,17 +39,17 @@ defmodule NervesHubDevice.ConsoleChannel do
   * `phx_close` or `phx_error` - This will cause the channel to attempt rejoining
   every 5 seconds. You can change the rejoin timing in the config
   ```
-  config :nerves_hub_device, rejoin_after: 3_000
+  config :nerves_hub_link, rejoin_after: 3_000
   ```
 
   For more info, see [The Erlang I/O Protocol](http://erlang.org/doc/apps/stdlib/io_protocol.html)
   """
 
   alias PhoenixClient.{Channel, Message}
-  alias NervesHubDevice.Client
+  alias NervesHubLink.Client
 
-  @client Application.get_env(:nerves_hub_device, :client, Client.Default)
-  @rejoin_after Application.get_env(:nerves_hub_device, :rejoin_after, 5_000)
+  @client Application.get_env(:nerves_hub_link, :client, Client.Default)
+  @rejoin_after Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
 
   defmodule State do
     defstruct socket: nil,

--- a/lib/nerves_hub_link/http_fwup_stream.ex
+++ b/lib/nerves_hub_link/http_fwup_stream.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubDevice.HTTPFwupStream do
+defmodule NervesHubLink.HTTPFwupStream do
   @moduledoc """
   Download and install a firmware update.
   """
@@ -56,10 +56,10 @@ defmodule NervesHubDevice.HTTPFwupStream do
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     args = ["--apply", "--no-unmount", "-d", devpath, "--task", "upgrade"]
 
-    fwup_public_keys = NervesHubDevice.Certificate.fwup_public_keys()
+    fwup_public_keys = NervesHubLink.Certificate.fwup_public_keys()
 
     if fwup_public_keys == [] do
-      Logger.error("No fwup public keys were configured for nerves_hub_device.")
+      Logger.error("No fwup public keys were configured for nerves_hub_link.")
       Logger.error("This means that firmware signatures are not being checked.")
       Logger.error("nerves_hub won't allow this in the future.")
     end

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -1,7 +1,7 @@
-defmodule NervesHubDevice.Socket do
+defmodule NervesHubLink.Socket do
   require Logger
 
-  alias NervesHubDevice.Certificate
+  alias NervesHubLink.Certificate
 
   @cert "nerves_hub_cert"
   @key "nerves_hub_key"
@@ -13,14 +13,14 @@ defmodule NervesHubDevice.Socket do
   def opts(opts \\ nil)
 
   def opts(nil) do
-    Application.get_env(:nerves_hub_device, :socket, [])
+    Application.get_env(:nerves_hub_link, :socket, [])
     |> opts()
   end
 
   def opts(user_config) when is_list(user_config) do
-    server_name = Application.get_env(:nerves_hub_device, :device_api_host)
-    server_port = Application.get_env(:nerves_hub_device, :device_api_port)
-    sni = Application.get_env(:nerves_hub_device, :device_api_sni)
+    server_name = Application.get_env(:nerves_hub_link, :device_api_host)
+    server_port = Application.get_env(:nerves_hub_link, :device_api_port)
+    sni = Application.get_env(:nerves_hub_link, :device_api_sni)
 
     url = "wss://#{server_name}:#{server_port}/socket/websocket"
 
@@ -71,10 +71,10 @@ defmodule NervesHubDevice.Socket do
   defp opts_from_nerves_key_or_config(user_config) do
     cacerts = user_config[:cacerts] || Certificate.ca_certs()
 
-    with nk_opts <- Application.get_env(:nerves_hub_device, :nerves_key, []),
+    with nk_opts <- Application.get_env(:nerves_hub_link, :nerves_key, []),
          true <- Keyword.get(nk_opts, :enabled, false),
          :nerves_key <- Application.get_application(NervesKey) do
-      Logger.debug("[NervesHubDevice] Reading SSL options from NervesKey")
+      Logger.debug("[NervesHubLink] Reading SSL options from NervesKey")
       # In the future, this may change to support other bus names
       # like "usb-something". But currently, ATECC508A and NervesKey.PKCS11
       # only support "i2c-N" scheme.
@@ -99,12 +99,12 @@ defmodule NervesHubDevice.Socket do
 
         [cert: cert, key: key, cacerts: cacerts]
       else
-        Logger.error("[NervesHubDevice] NervesKey isn't provisioned, so not using.")
+        Logger.error("[NervesHubLink] NervesKey isn't provisioned, so not using.")
         []
       end
     else
       _ ->
-        Logger.debug("[NervesHubDevice] Using user configured SSL options")
+        Logger.debug("[NervesHubLink] Using user configured SSL options")
 
         [cert(user_config), key(user_config), cacerts: cacerts]
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,15 +1,15 @@
-defmodule NervesHubDevice.MixProject do
+defmodule NervesHubLink.MixProject do
   use Mix.Project
 
   Application.put_env(
-    :nerves_hub_device,
+    :nerves_hub_link,
     :nerves_provisioning,
     Path.expand("priv/provisioning.conf")
   )
 
   def project do
     [
-      app: :nerves_hub_device,
+      app: :nerves_hub_link,
       deps: deps(),
       description: description(),
       docs: [main: "readme", extras: ["README.md"]],
@@ -37,7 +37,7 @@ defmodule NervesHubDevice.MixProject do
         fwup_public_keys: []
       ],
       extra_applications: [:logger, :iex],
-      mod: {NervesHubDevice.Application, []}
+      mod: {NervesHubLink.Application, []}
     ]
   end
 
@@ -52,7 +52,7 @@ defmodule NervesHubDevice.MixProject do
   defp package do
     [
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/smartrent/nerves_hub_device"}
+      links: %{"GitHub" => "https://github.com/smartrent/nerves_hub_link"}
     ]
   end
 

--- a/test/nerves_hub_device/certificate_test.exs
+++ b/test/nerves_hub_device/certificate_test.exs
@@ -1,12 +1,12 @@
-defmodule NervesHubDevice.CertificateTest do
+defmodule NervesHubLink.CertificateTest do
   use ExUnit.Case, async: true
-  alias NervesHubDevice.Certificate
+  alias NervesHubLink.Certificate
 
   doctest Certificate
 
   describe "pem_to_der/1" do
     test "decodes certificate" do
-      pem = File.read!(Path.join([:code.priv_dir(:nerves_hub_device), "ca_certs", "ca.pem"]))
+      pem = File.read!(Path.join([:code.priv_dir(:nerves_hub_link), "ca_certs", "ca.pem"]))
       assert is_binary(Certificate.pem_to_der(pem))
     end
 

--- a/test/nerves_hub_device/channel_test.exs
+++ b/test/nerves_hub_device/channel_test.exs
@@ -1,8 +1,8 @@
-defmodule NervesHubDevice.ChannelTest do
+defmodule NervesHubLink.ChannelTest do
   # Fwup can only have one instance at a time.
   # Set async false to account for this
   use ExUnit.Case, async: true
-  alias NervesHubDevice.{ClientMock, Channel}
+  alias NervesHubLink.{ClientMock, Channel}
   alias PhoenixClient.Message
 
   doctest Channel
@@ -80,7 +80,7 @@ defmodule NervesHubDevice.ChannelTest do
     # This fails without starting the connection Agent.
     # Not sure why
     # TODO: Manage this agent better. Remove from test
-    NervesHubDevice.Connection.start_link([])
+    NervesHubLink.Connection.start_link([])
 
     assert Channel.handle_info(%Message{event: "phx_close", payload: %{}}, state) ==
              {:noreply, %Channel.State{connected?: false}}

--- a/test/nerves_hub_device/client/default_test.exs
+++ b/test/nerves_hub_device/client/default_test.exs
@@ -1,6 +1,6 @@
-defmodule NervesHubDevice.Client.DefaultTest do
+defmodule NervesHubLink.Client.DefaultTest do
   use ExUnit.Case, async: true
-  alias NervesHubDevice.Client.Default
+  alias NervesHubLink.Client.Default
 
   doctest Default
 

--- a/test/nerves_hub_device/client_test.exs
+++ b/test/nerves_hub_device/client_test.exs
@@ -1,6 +1,6 @@
-defmodule NervesHubDevice.ClientTest do
+defmodule NervesHubLink.ClientTest do
   use ExUnit.Case, async: true
-  alias NervesHubDevice.{Client, ClientMock}
+  alias NervesHubLink.{Client, ClientMock}
 
   doctest Client
 

--- a/test/nerves_hub_device/console_channel_test.exs
+++ b/test/nerves_hub_device/console_channel_test.exs
@@ -1,6 +1,6 @@
-defmodule NervesHubDevice.ConsoleChannelTest do
+defmodule NervesHubLink.ConsoleChannelTest do
   use ExUnit.Case, async: false
-  alias NervesHubDevice.{ClientMock, ConsoleChannel}
+  alias NervesHubLink.{ClientMock, ConsoleChannel}
   alias PhoenixClient.Message
 
   doctest ConsoleChannel
@@ -8,7 +8,7 @@ defmodule NervesHubDevice.ConsoleChannelTest do
   setup context do
     context = Map.put(context, :state, %ConsoleChannel.State{})
     :ok = Application.ensure_started(:iex)
-    Application.put_env(:nerves_hub_device, :remote_iex, true)
+    Application.put_env(:nerves_hub_link, :remote_iex, true)
     Mox.verify_on_exit!(context)
     context
   end

--- a/test/nerves_hub_device/socket_test.exs
+++ b/test/nerves_hub_device/socket_test.exs
@@ -1,6 +1,6 @@
-defmodule NervesHubDevice.SocketTest do
+defmodule NervesHubLink.SocketTest do
   use ExUnit.Case, async: true
-  alias NervesHubDevice.{Certificate, Socket}
+  alias NervesHubLink.{Certificate, Socket}
 
   doctest Socket
 

--- a/test/nerves_hub_device_test.exs
+++ b/test/nerves_hub_device_test.exs
@@ -1,5 +1,5 @@
-defmodule NervesHubDeviceTest do
+defmodule NervesHubLinkTest do
   use ExUnit.Case, async: true
 
-  doctest NervesHubDevice
+  doctest NervesHubLink
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,1 +1,1 @@
-Mox.defmock(NervesHubDevice.ClientMock, for: NervesHubDevice.Client)
+Mox.defmock(NervesHubLink.ClientMock, for: NervesHubLink.Client)


### PR DESCRIPTION
The short history of this is that `nerves_hub` library had a few shortcomings we wanted to overcome such as the slight confusion in the naming and the intermixing of `http` and `channel` support making unique edge-cases.

An experiment was done which forked `nerves_hub` into `nerves_hub_device` to test a few notable ideas:
  * Remove `HTTP` support to use channels exclusively
  * Reorganize as a an `Application` and remove ability to start a supervisor separately
  * Support using `NervesKey` via a configuartion flag (for ease of use)

We've been using this at Smartrent and after the last [Nerves stand-up meeting](https://github.com/nerves-project/nerves/wiki/Core-Team-Stand-Up-Meeting-Notes#jon-carstens) decided rename it to `NervesHubLink` and bring it over to NervesHub scope, which is what this PR does.

I've kept the fork up-to-date with changes in `NervesHub` that pertain to channels, so we shouldn't be missing any existing features.