### PR TITLE
Don't apply update when update already in progress

### DIFF
--- a/lib/nerves_hub_link/channel.ex
+++ b/lib/nerves_hub_link/channel.ex
@@ -134,6 +134,16 @@ defmodule NervesHubLink.Channel do
 
   def terminate(_reason, _state), do: NervesHubLink.Connection.disconnected()
 
+  defp maybe_update_firmware(_data, %{status: {:updating, _percent}} = state) do
+    # Received an update message from NervesHub, but we're already in progress.
+    # It could be because the deployment/device was edited making a duplicate
+    # update message or a new deployment was created. Either way, lets not
+    # interrupt FWUP and let the task finish. After update and reboot, the
+    # device will check-in and get an update message if it was actually new and
+    # required
+    state
+  end
+
   defp maybe_update_firmware(%{"firmware_url" => url} = data, state) do
     # Cancel an existing timer if it exists.
     # This prevents rescheduled updates`

--- a/test/nerves_hub_link/channel_test.exs
+++ b/test/nerves_hub_link/channel_test.exs
@@ -74,6 +74,17 @@ defmodule NervesHubLink.ChannelTest do
     test "catch all" do
       assert Channel.handle_info(:any, :state) == {:noreply, :state}
     end
+
+    test "update already in progress", %{state: state} do
+      state = %{state | status: {:updating, 20}}
+
+      # State is unchanged, effectively ignored
+      assert {:noreply, ^state} =
+               Channel.handle_info(
+                 %Message{event: "update", payload: %{"firmware_url" => ""}},
+                 state
+               )
+    end
   end
 
   test "handle_close", %{state: state} do


### PR DESCRIPTION
Fixes #8

Some events in nerves-hub.org will trigger an update message to be sent, such as editing
a deployment/device (changing the name and saving, etc).

If a device gets that message while it is already updating, things will crash. This shouldn't
be too much of an issue because the whole channel crashes, reconnects, and gets the update
message again. But it produces some nasty error that might be confusing to the user.

So to help avoid this edge-case, let's just ignore update messages while in the process of
updating. Should it actually be new/required, we'll get the message again on next startup after
rebooting.