### PR TITLE
Rename Channel to DeviceChannel

### DIFF
--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -4,7 +4,7 @@ defmodule NervesHubLink do
   """
   @spec connected? :: boolean()
   def connected?() do
-    channel_state()
+    device_channel_state()
     |> Map.get(:connected?, false)
   end
 
@@ -19,14 +19,14 @@ defmodule NervesHubLink do
   @doc """
   Current status of the device channel
   """
-  @spec status :: NervesHubLink.Channel.State.status()
+  @spec status :: NervesHubLink.DeviceChannel.State.status()
   def status() do
-    channel_state()
+    device_channel_state()
     |> Map.get(:status, :unknown)
   end
 
-  defp channel_state() do
-    GenServer.whereis(NervesHubLink.Channel)
+  defp device_channel_state() do
+    GenServer.whereis(NervesHubLink.DeviceChannel)
     |> case do
       channel when is_pid(channel) -> GenServer.call(channel, :get_state)
       _ -> %{}

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubLink.Application do
   use Application
 
-  alias NervesHubLink.{Channel, Configurator, Connection, ConsoleChannel, Socket}
+  alias NervesHubLink.{DeviceChannel, Configurator, Connection, ConsoleChannel, Socket}
 
   def start(_type, _args) do
     config = Configurator.build()
@@ -10,7 +10,7 @@ defmodule NervesHubLink.Application do
       [
         Connection,
         {PhoenixClient.Socket, {config.socket, [name: Socket]}},
-        {Channel, [socket: Socket, topic: "device", params: config.params]}
+        {DeviceChannel, [socket: Socket, params: config.params]}
       ]
       |> add_console_child(config)
 

--- a/lib/nerves_hub_link/device_channel.ex
+++ b/lib/nerves_hub_link/device_channel.ex
@@ -1,4 +1,4 @@
-defmodule NervesHubLink.Channel do
+defmodule NervesHubLink.DeviceChannel do
   use GenServer
   require Logger
 


### PR DESCRIPTION
This is to disambiguate between the upper level (NervesHubLink) and lower level (PhoenixClient).