### PR TITLE
Fix missing module test warnings

### DIFF
--- a/test/nerves_hub_link/client_test.exs
+++ b/test/nerves_hub_link/client_test.exs
@@ -2,6 +2,9 @@ defmodule NervesHubLink.ClientTest do
   use ExUnit.Case, async: true
   alias NervesHubLink.{Client, ClientMock}
 
+  @compile {:no_warn_undefined, {Not, :real, 0}}
+  @compile {:no_warn_undefined, {:something, :exception, 1}}
+
   doctest Client
 
   setup context, do: Mox.verify_on_exit!(context)


### PR DESCRIPTION
Fixes
```
warning: Not.real/0 is undefined (module Not is not available or is yet to be defined)
  test/nerves_hub_link/client_test.exs:50: NervesHubLink.ClientTest."test apply_wrap doesn't propagate failures exception"/1

warning: :something.exception/1 is undefined (module :something is not available or is yet to be defined)
  test/nerves_hub_link/client_test.exs:35: NervesHubLink.ClientTest."test apply_wrap doesn't propagate failures error"/1
```