### PR TITLE
Consolidate Client logic to Client module

### DIFF
--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -79,9 +79,9 @@ defmodule NervesHubLink.Client do
   @doc """
   This function is called internally by NervesHubLink to notify clients.
   """
-  @spec update_available(module(), update_data()) :: update_response()
-  def update_available(client, data) do
-    case apply_wrap(client, :update_available, [data]) do
+  @spec update_available(update_data()) :: update_response()
+  def update_available(data) do
+    case apply_wrap(mod(), :update_available, [data]) do
       :apply ->
         :apply
 
@@ -93,9 +93,7 @@ defmodule NervesHubLink.Client do
 
       wrong ->
         Logger.error(
-          "[NervesHubLink] Client: #{client}.update_available/1 bad return value: #{
-            inspect(wrong)
-          } Applying update."
+          "[NervesHubLink] Client: #{mod()}.update_available/1 bad return value: #{inspect(wrong)} Applying update."
         )
 
         :apply
@@ -105,26 +103,30 @@ defmodule NervesHubLink.Client do
   @doc """
   This function is called internally by NervesHubLink to notify clients of fwup progress.
   """
-  @spec handle_fwup_message(module(), fwup_message()) :: :ok
-  def handle_fwup_message(client, data) do
-    _ = apply_wrap(client, :handle_fwup_message, [data])
+  @spec handle_fwup_message(fwup_message()) :: :ok
+  def handle_fwup_message(data) do
+    _ = apply_wrap(mod(), :handle_fwup_message, [data])
     :ok
   end
 
   @doc """
   This function is called internally by NervesHubLink to notify clients of fwup errors.
   """
-  @spec handle_error(module(), any()) :: :ok
-  def handle_error(client, data) do
-    _ = apply_wrap(client, :handle_error, [data])
+  @spec handle_error(any()) :: :ok
+  def handle_error(data) do
+    _ = apply_wrap(mod(), :handle_error, [data])
   end
 
   # Catches exceptions and exits
-  defp apply_wrap(client, function, args) do
-    apply(client, function, args)
+  defp apply_wrap(mod, function, args) do
+    apply(mod, function, args)
   catch
     :error, reason -> {:error, reason}
     :exit, reason -> {:exit, reason}
     err -> err
+  end
+
+  defp mod() do
+    Application.get_env(:nerves_hub_link, :client, Client.Default)
   end
 end

--- a/test/nerves_hub_link/client_test.exs
+++ b/test/nerves_hub_link/client_test.exs
@@ -7,51 +7,53 @@ defmodule NervesHubLink.ClientTest do
 
   doctest Client
 
-  setup context, do: Mox.verify_on_exit!(context)
+  setup context do
+    Mox.verify_on_exit!(context)
+  end
 
   test "update_available/2" do
     Mox.expect(ClientMock, :update_available, fn :data -> :apply end)
-    assert Client.update_available(ClientMock, :data) == :apply
+    assert Client.update_available(:data) == :apply
 
     Mox.expect(ClientMock, :update_available, fn :data -> :wrong end)
-    assert Client.update_available(ClientMock, :data) == :apply
+    assert Client.update_available(:data) == :apply
 
     Mox.expect(ClientMock, :update_available, fn :data -> :ignore end)
-    assert Client.update_available(ClientMock, :data) == :ignore
+    assert Client.update_available(:data) == :ignore
 
     Mox.expect(ClientMock, :update_available, fn :data -> {:reschedule, 1337} end)
-    assert Client.update_available(ClientMock, :data) == {:reschedule, 1337}
+    assert Client.update_available(:data) == {:reschedule, 1337}
   end
 
   test "handle_fwup_message/2" do
     Mox.expect(ClientMock, :handle_fwup_message, fn :data -> :ok end)
-    assert Client.handle_fwup_message(ClientMock, :data) == :ok
+    assert Client.handle_fwup_message(:data) == :ok
   end
 
   test "handle_error/2" do
     Mox.expect(ClientMock, :handle_error, fn :data -> :ok end)
-    assert Client.handle_error(ClientMock, :data) == :ok
+    assert Client.handle_error(:data) == :ok
   end
 
   describe "apply_wrap doesn't propagate failures" do
     test "error" do
       Mox.expect(ClientMock, :handle_fwup_message, fn :data -> raise :something end)
-      assert Client.handle_fwup_message(ClientMock, :data) == :ok
+      assert Client.handle_fwup_message(:data) == :ok
     end
 
     test "exit" do
       Mox.expect(ClientMock, :handle_fwup_message, fn :data -> exit(:reason) end)
-      assert Client.handle_fwup_message(ClientMock, :data) == :ok
+      assert Client.handle_fwup_message(:data) == :ok
     end
 
     test "throw" do
       Mox.expect(ClientMock, :handle_fwup_message, fn :data -> throw(:reason) end)
-      assert Client.handle_fwup_message(ClientMock, :data) == :ok
+      assert Client.handle_fwup_message(:data) == :ok
     end
 
     test "exception" do
       Mox.expect(ClientMock, :handle_fwup_message, fn :data -> Not.real() end)
-      assert Client.handle_fwup_message(ClientMock, :data) == :ok
+      assert Client.handle_fwup_message(:data) == :ok
     end
   end
 end


### PR DESCRIPTION
This removes compile time calls to determine the module to use for the Client and shifts it to the runtime.