### PR TITLE
Abstract the update code from the device_channel.

### DIFF
--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -3,10 +3,7 @@ defmodule NervesHubLink do
   Checks if the device is connected to the NervesHub channel.
   """
   @spec connected? :: boolean()
-  def connected?() do
-    device_channel_state()
-    |> Map.get(:connected?, false)
-  end
+  defdelegate connected?(), to: NervesHubLink.DeviceChannel
 
   @doc """
   Checks if the device has a socket connection with NervesHub
@@ -17,19 +14,8 @@ defmodule NervesHubLink do
     as: :connected?
 
   @doc """
-  Current status of the device channel
+  Current status of the update manager
   """
-  @spec status :: NervesHubLink.DeviceChannel.State.status()
-  def status() do
-    device_channel_state()
-    |> Map.get(:status, :unknown)
-  end
-
-  defp device_channel_state() do
-    GenServer.whereis(NervesHubLink.DeviceChannel)
-    |> case do
-      channel when is_pid(channel) -> GenServer.call(channel, :get_state)
-      _ -> %{}
-    end
-  end
+  @spec status :: NervesHubLink.UpdateManager.State.status()
+  defdelegate status(), to: NervesHubLink.UpdateManager
 end

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -1,7 +1,14 @@
 defmodule NervesHubLink.Application do
   use Application
 
-  alias NervesHubLink.{DeviceChannel, Configurator, Connection, ConsoleChannel, Socket}
+  alias NervesHubLink.{
+    DeviceChannel,
+    Configurator,
+    Connection,
+    ConsoleChannel,
+    Socket,
+    UpdateManager
+  }
 
   def start(_type, _args) do
     config = Configurator.build()
@@ -10,7 +17,8 @@ defmodule NervesHubLink.Application do
       [
         Connection,
         {PhoenixClient.Socket, {config.socket, [name: Socket]}},
-        {DeviceChannel, [socket: Socket, params: config.params]}
+        {DeviceChannel, [socket: Socket, params: config.params]},
+        UpdateManager
       ]
       |> add_console_child(config)
 

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -81,9 +81,7 @@ defmodule NervesHubLink.Client do
   """
   @spec update_available(update_data()) :: update_response()
   def update_available(data) do
-    ret = apply_wrap(mod(), :update_available, [data])
-
-    case ret do
+    case apply_wrap(mod(), :update_available, [data]) do
       :apply ->
         :apply
 

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -81,7 +81,9 @@ defmodule NervesHubLink.Client do
   """
   @spec update_available(update_data()) :: update_response()
   def update_available(data) do
-    case apply_wrap(mod(), :update_available, [data]) do
+    ret = apply_wrap(mod(), :update_available, [data])
+
+    case ret do
       :apply ->
         :apply
 

--- a/lib/nerves_hub_link/device_channel.ex
+++ b/lib/nerves_hub_link/device_channel.ex
@@ -2,25 +2,16 @@ defmodule NervesHubLink.DeviceChannel do
   use GenServer
   require Logger
 
-  alias NervesHubLink.{Client, HTTPFwupStream}
+  alias NervesHubLink.{Client, UpdateManager}
   alias PhoenixClient.{Channel, Message}
 
   @rejoin_after Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
 
   defmodule State do
-    @type status ::
-            :idle
-            | :fwup_error
-            | :update_failed
-            | :update_rescheduled
-            | {:updating, integer()}
-            | :unknown
-
     @type t :: %__MODULE__{
             channel: pid(),
             connected?: boolean(),
             params: map(),
-            status: status(),
             socket: pid(),
             topic: String.t()
           }
@@ -29,7 +20,6 @@ defmodule NervesHubLink.DeviceChannel do
               topic: "device",
               channel: nil,
               params: %{},
-              status: :idle,
               connected?: false
   end
 
@@ -37,12 +27,36 @@ defmodule NervesHubLink.DeviceChannel do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  def send_update_progress(progress) do
+    GenServer.cast(__MODULE__, {:send_update_progress, progress})
+  end
+
+  def send_update_status(status) do
+    GenServer.cast(__MODULE__, {:send_update_status, status})
+  end
+
+  def connected?() do
+    GenServer.call(__MODULE__, :connected?)
+  end
+
   def init(opts) do
     send(self(), :join)
     {:ok, struct(State, opts)}
   end
 
-  def handle_call(:get_state, _from, state), do: {:reply, state, state}
+  def handle_call(:connected?, _from, %{connected?: connected?} = state) do
+    {:reply, connected?, state}
+  end
+
+  def handle_cast({:send_update_progress, progress}, state) do
+    Channel.push_async(state.channel, "fwup_progress", %{value: progress})
+    {:noreply, state}
+  end
+
+  def handle_cast({:send_update_status, status}, state) do
+    Channel.push_async(state.channel, "status_update", %{status: status})
+    {:noreply, state}
+  end
 
   def handle_info(%Message{event: "reboot"}, state) do
     Logger.warn("Reboot Request from NervesHubLink")
@@ -52,8 +66,9 @@ defmodule NervesHubLink.DeviceChannel do
     {:noreply, state}
   end
 
-  def handle_info(%Message{event: "update", payload: params}, state) do
-    {:noreply, maybe_update_firmware(params, state)}
+  def handle_info(%Message{event: "update", payload: update}, state) do
+    UpdateManager.apply_update(update)
+    {:noreply, state}
   end
 
   def handle_info(%Message{event: event, payload: payload}, state)
@@ -69,8 +84,8 @@ defmodule NervesHubLink.DeviceChannel do
     case Channel.join(socket, topic, params) do
       {:ok, reply, channel} ->
         NervesHubLink.Connection.connected()
-        state = %{state | channel: channel, connected?: true}
-        {:noreply, maybe_update_firmware(reply, state)}
+        _ = handle_join_reply(reply)
+        {:noreply, %{state | channel: channel, connected?: true}}
 
       _error ->
         NervesHubLink.Connection.disconnected()
@@ -79,106 +94,15 @@ defmodule NervesHubLink.DeviceChannel do
     end
   end
 
-  def handle_info({:fwup, {:ok, _status, _info} = message}, state) do
-    Logger.info("[NervesHubLink] FWUP Finished")
-    _ = Client.handle_fwup_message(message)
-    Nerves.Runtime.reboot()
-    {:noreply, state}
-  end
-
-  def handle_info({:fwup, message}, state) do
-    state =
-      case message do
-        {:progress, percent} ->
-          Channel.push_async(state.channel, "fwup_progress", %{value: percent})
-          %{state | status: {:updating, percent}}
-
-        {:error, _, _message} ->
-          Channel.push_async(state.channel, "status_update", %{status: "fwup error"})
-          %{state | status: :fwup_error}
-
-        _ ->
-          state
-      end
-
-    _ = Client.handle_fwup_message(message)
-    {:noreply, state}
-  end
-
-  def handle_info({:http_error, error}, state) do
-    _ = Client.handle_error(error)
-    Channel.push_async(state.channel, "status_update", %{status: "update failed"})
-    {:noreply, %{state | status: :update_failed}}
-  end
-
-  def handle_info({:update_reschedule, response}, state) do
-    {:noreply, maybe_update_firmware(response, state)}
-  end
-
-  def handle_info({:DOWN, _, :process, _, :normal}, state) do
-    {:noreply, state}
-  end
-
-  def handle_info({:DOWN, _, :process, _, reason}, state) do
-    Logger.error("HTTP Streaming Error: #{inspect(reason)}")
-    _ = Client.handle_error(reason)
-    Channel.push_async(state.channel, "status_update", %{status: "update failed"})
-    {:noreply, %{state | status: :update_failed}}
-  end
-
   def handle_info(_message, state) do
     {:noreply, state}
   end
 
   def terminate(_reason, _state), do: NervesHubLink.Connection.disconnected()
 
-  defp maybe_update_firmware(_data, %{status: {:updating, _percent}} = state) do
-    # Received an update message from NervesHub, but we're already in progress.
-    # It could be because the deployment/device was edited making a duplicate
-    # update message or a new deployment was created. Either way, lets not
-    # interrupt FWUP and let the task finish. After update and reboot, the
-    # device will check-in and get an update message if it was actually new and
-    # required
-    state
+  defp handle_join_reply(%{"firmware_url" => _url} = update) do
+    UpdateManager.apply_update(update)
   end
 
-  defp maybe_update_firmware(%{"firmware_url" => url} = data, state) do
-    # Cancel an existing timer if it exists.
-    # This prevents rescheduled updates`
-    # from compounding.
-    state = maybe_cancel_timer(state, :update_reschedule_timer)
-
-    # possibly offload update decision to an external module.
-    # This will allow application developers
-    # to control exactly when an update is applied.
-    case Client.update_available(data) do
-      :apply ->
-        {:ok, http} = HTTPFwupStream.start(self())
-        spawn_monitor(HTTPFwupStream, :get, [http, url])
-        Logger.info("[NervesHubLink] Downloading firmware: #{url}")
-        %{state | status: {:updating, 0}}
-
-      :ignore ->
-        state
-
-      {:reschedule, ms} ->
-        timer = Process.send_after(self(), {:update_reschedule, data}, ms)
-        Logger.info("[NervesHubLink] rescheduling firmware update in #{ms} milliseconds")
-        state = Map.put(state, :update_reschedule_timer, timer)
-
-        %{state | status: :update_rescheduled}
-    end
-  end
-
-  defp maybe_update_firmware(_, state), do: state
-
-  defp maybe_cancel_timer(state, key) do
-    timer = Map.get(state, key)
-
-    if timer && Process.read_timer(timer) do
-      Process.cancel_timer(timer)
-    end
-
-    Map.delete(state, key)
-  end
+  defp handle_join_reply(_), do: :noop
 end

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -1,0 +1,144 @@
+defmodule NervesHubLink.UpdateManager do
+  use GenServer
+  require Logger
+
+  alias NervesHubLink.{DeviceChannel, Client, HTTPFwupStream}
+
+  defmodule State do
+    @type status ::
+            :idle
+            | :fwup_error
+            | :update_failed
+            | :update_rescheduled
+            | {:updating, integer()}
+            | :unknown
+
+    @type t :: %__MODULE__{
+            status: status(),
+            update_reschedule_timer: nil | pid()
+          }
+
+    defstruct status: :idle,
+              update_reschedule_timer: nil
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def apply_update(update) do
+    GenServer.call(__MODULE__, {:apply_update, update})
+  end
+
+  def status() do
+    GenServer.call(__MODULE__, :status)
+  end
+
+  def init(_opts) do
+    {:ok, %State{}}
+  end
+
+  def handle_call({:apply_update, update}, _from, state) do
+    state = maybe_update_firmware(update, state)
+    {:reply, state.status, state}
+  end
+
+  def handle_call(:status, _from, %{status: status} = state) do
+    {:reply, status, state}
+  end
+
+  def handle_info({:fwup, {:ok, 0, message}}, state) do
+    Logger.info("[NervesHubLink] FWUP Finished")
+    _ = Client.handle_fwup_message(message)
+    Nerves.Runtime.reboot()
+    {:noreply, state}
+  end
+
+  def handle_info({:fwup, message}, state) do
+    state =
+      case message do
+        {:progress, percent} ->
+          DeviceChannel.send_update_progress(percent)
+          %{state | status: {:updating, percent}}
+
+        {:error, _, _message} ->
+          DeviceChannel.send_update_status("fwup error")
+          %{state | status: :fwup_error}
+
+        _ ->
+          state
+      end
+
+    _ = Client.handle_fwup_message(message)
+    {:noreply, state}
+  end
+
+  def handle_info({:http_error, error}, state) do
+    _ = Client.handle_error(error)
+    DeviceChannel.send_update_status("update failed")
+    {:noreply, %{state | status: :update_failed}}
+  end
+
+  def handle_info({:update_reschedule, response}, state) do
+    {:noreply, maybe_update_firmware(response, %{state | update_reschedule_timer: nil})}
+  end
+
+  def handle_info({:DOWN, _, :process, _, :normal}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _, :process, _, reason}, state) do
+    Logger.error("HTTP Streaming Error: #{inspect(reason)}")
+    _ = Client.handle_error(reason)
+    DeviceChannel.send_update_status("update failed")
+    {:noreply, %{state | status: :update_failed}}
+  end
+
+  defp maybe_update_firmware(_data, %{status: {:updating, _percent}} = state) do
+    # Received an update message from NervesHub, but we're already in progress.
+    # It could be because the deployment/device was edited making a duplicate
+    # update message or a new deployment was created. Either way, lets not
+    # interrupt FWUP and let the task finish. After update and reboot, the
+    # device will check-in and get an update message if it was actually new and
+    # required
+    state
+  end
+
+  defp maybe_update_firmware(%{"firmware_url" => url} = data, state) do
+    # Cancel an existing timer if it exists.
+    # This prevents rescheduled updates`
+    # from compounding.
+    state = maybe_cancel_timer(state)
+
+    # possibly offload update decision to an external module.
+    # This will allow application developers
+    # to control exactly when an update is applied.
+    case Client.update_available(data) do
+      :apply ->
+        {:ok, http} = HTTPFwupStream.start(self())
+        spawn_monitor(HTTPFwupStream, :get, [http, url])
+        Logger.info("[NervesHubLink] Downloading firmware: #{url}")
+        %{state | status: {:updating, 0}}
+
+      :ignore ->
+        state
+
+      {:reschedule, ms} ->
+        timer = Process.send_after(self(), {:update_reschedule, data}, ms)
+        Logger.info("[NervesHubLink] rescheduling firmware update in #{ms} milliseconds")
+        %{state | status: :update_rescheduled, update_reschedule_timer: timer}
+    end
+  end
+
+  defp maybe_update_firmware(_, state), do: state
+
+  defp maybe_cancel_timer(%{update_reschedule_timer: nil} = state), do: state
+
+  defp maybe_cancel_timer(%{update_reschedule_timer: timer} = state) do
+    if Process.read_timer(timer) do
+      Process.cancel_timer(timer)
+    end
+
+    %{state | update_reschedule_timer: nil}
+  end
+end

--- a/test/nerves_hub_link/device_channel_test.exs
+++ b/test/nerves_hub_link/device_channel_test.exs
@@ -2,89 +2,13 @@ defmodule NervesHubLink.DeviceChannelTest do
   # Fwup can only have one instance at a time.
   # Set async false to account for this
   use ExUnit.Case, async: true
-  alias NervesHubLink.{ClientMock, DeviceChannel}
+  alias NervesHubLink.DeviceChannel
   alias PhoenixClient.Message
 
   doctest DeviceChannel
 
   setup do
-    # hack to stop Fwup streams if one was running
-    try do
-      if Process.whereis(Fwup.Stream), do: GenServer.stop(Fwup.Stream)
-    catch
-      _, _ -> :ok
-    end
-
     %{state: %DeviceChannel.State{}}
-  end
-
-  setup context, do: Mox.verify_on_exit!(context)
-
-  describe "handle_in/3 - update" do
-    test "no firmware url" do
-      Mox.expect(ClientMock, :update_available, 0, fn _ -> :ok end)
-      assert DeviceChannel.handle_info(%Message{event: "update"}, %{}) == {:noreply, %{}}
-    end
-
-    test "firmware url - apply", %{state: state} do
-      Mox.expect(ClientMock, :update_available, fn _ -> :apply end)
-
-      assert DeviceChannel.handle_info(
-               %Message{event: "update", payload: %{"firmware_url" => ""}},
-               state
-             ) == {:noreply, %DeviceChannel.State{status: {:updating, 0}}}
-    end
-
-    test "firmware url - ignore" do
-      Mox.expect(ClientMock, :update_available, fn _ -> :ignore end)
-
-      assert DeviceChannel.handle_info(
-               %Message{event: "update", payload: %{"firmware_url" => ""}},
-               %{}
-             ) == {:noreply, %{}}
-    end
-
-    test "firmware url - reschedule", %{state: state} do
-      data = %{"firmware_url" => ""}
-      Mox.expect(ClientMock, :update_available, fn _ -> {:reschedule, 999} end)
-
-      assert {:noreply, state} =
-               DeviceChannel.handle_info(%Message{event: "update", payload: data}, state)
-
-      Mox.expect(ClientMock, :update_available, fn _ -> {:reschedule, 1} end)
-
-      assert {:noreply, %{} = state} =
-               DeviceChannel.handle_info(%Message{event: "update", payload: data}, state)
-
-      assert_receive {:update_reschedule, ^data}
-    end
-
-    test "firmware url - removes existing timer" do
-      data = %{"firmware_url" => ""}
-      Mox.expect(ClientMock, :update_available, fn _ -> :ignore end)
-
-      assert {:noreply, state} =
-               DeviceChannel.handle_info(%Message{event: "update", payload: data}, %{
-                 update_reschedule_timer: nil
-               })
-
-      refute Map.has_key?(state, :update_reschedule_timer)
-    end
-
-    test "catch all" do
-      assert DeviceChannel.handle_info(:any, :state) == {:noreply, :state}
-    end
-
-    test "update already in progress", %{state: state} do
-      state = %{state | status: {:updating, 20}}
-
-      # State is unchanged, effectively ignored
-      assert {:noreply, ^state} =
-               DeviceChannel.handle_info(
-                 %Message{event: "update", payload: %{"firmware_url" => ""}},
-                 state
-               )
-    end
   end
 
   test "handle_close", %{state: state} do
@@ -97,43 +21,5 @@ defmodule NervesHubLink.DeviceChannelTest do
              {:noreply, %DeviceChannel.State{connected?: false}}
 
     assert_receive :join
-  end
-
-  describe "handle_info" do
-    test "fwup", %{state: state} do
-      message = {:ok, 1, "message"}
-      Mox.expect(ClientMock, :handle_fwup_message, fn ^message -> :ok end)
-      assert DeviceChannel.handle_info({:fwup, message}, state) == {:noreply, state}
-    end
-
-    test "http_error", %{state: state} do
-      error = "error"
-      Mox.expect(ClientMock, :handle_error, fn ^error -> :apply end)
-
-      assert DeviceChannel.handle_info({:http_error, error}, state) ==
-               {:noreply, %DeviceChannel.State{status: :update_failed}}
-    end
-
-    test "update_reschedule", %{state: state} do
-      data = %{"firmware_url" => ""}
-      Mox.expect(ClientMock, :update_available, fn ^data -> :apply end)
-
-      assert DeviceChannel.handle_info({:update_reschedule, data}, state) ==
-               {:noreply, %DeviceChannel.State{status: {:updating, 0}}}
-    end
-  end
-
-  describe "handle_info - down" do
-    test "normal", %{state: state} do
-      assert DeviceChannel.handle_info({:DOWN, :any, :process, :any, :normal}, state) ==
-               {:noreply, state}
-    end
-
-    test "non-normal", %{state: state} do
-      Mox.expect(ClientMock, :handle_error, 1, fn _ -> :ok end)
-
-      assert DeviceChannel.handle_info({:DOWN, :any, :process, :any, :"non-normal"}, state) ==
-               {:noreply, %DeviceChannel.State{status: :update_failed}}
-    end
   end
 end

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -1,0 +1,127 @@
+defmodule NervesHubLink.UpdateManagerTest do
+  use ExUnit.Case, async: true
+  alias NervesHubLink.{UpdateManager, ClientMock}
+
+  doctest UpdateManager
+
+  setup do
+    # hack to stop Fwup streams if one was running
+    try do
+      if Process.whereis(Fwup.Stream), do: GenServer.stop(Fwup.Stream)
+    catch
+      _, _ -> :ok
+    end
+
+    %{state: %UpdateManager.State{}}
+  end
+
+  setup context, do: Mox.verify_on_exit!(context)
+
+  describe "handle_call/3 - apply_update" do
+    test "no firmware url", %{state: state} do
+      Mox.expect(ClientMock, :update_available, 0, fn _ -> :ok end)
+      assert UpdateManager.handle_call({:apply_update, %{}}, nil, state) == {:reply, :idle, state}
+    end
+
+    test "firmware url - apply", %{state: state} do
+      Mox.expect(ClientMock, :update_available, fn _ -> :apply end)
+
+      assert {:reply, {:updating, 0}, _} =
+               UpdateManager.handle_call(
+                 {:apply_update, %{"firmware_url" => ""}},
+                 nil,
+                 state
+               )
+    end
+
+    test "firmware url - ignore", %{state: state} do
+      Mox.expect(ClientMock, :update_available, fn _ -> :ignore end)
+
+      assert {:reply, :idle, _} =
+               UpdateManager.handle_call(
+                 {:apply_update, %{"firmware_url" => ""}},
+                 nil,
+                 state
+               )
+    end
+
+    test "firmware url - reschedule", %{state: state} do
+      data = %{"firmware_url" => ""}
+      Mox.expect(ClientMock, :update_available, fn _ -> {:reschedule, 999} end)
+
+      assert {:reply, :update_rescheduled, _} =
+               UpdateManager.handle_call({:apply_update, data}, nil, state)
+
+      Mox.expect(ClientMock, :update_available, fn _ -> {:reschedule, 1} end)
+
+      assert {:reply, :update_rescheduled, _} =
+               UpdateManager.handle_call({:apply_update, data}, nil, state)
+
+      assert_receive {:update_reschedule, ^data}
+    end
+
+    test "firmware url - removes existing timer", %{state: state} do
+      data = %{"firmware_url" => ""}
+      Mox.expect(ClientMock, :update_available, fn _ -> :ignore end)
+
+      assert {:reply, _, state} =
+               UpdateManager.handle_call(
+                 {:apply_update, data},
+                 nil,
+                 %{state | update_reschedule_timer: Process.send_after(self(), :timer, 10_000)}
+               )
+
+      refute state.update_reschedule_timer
+    end
+
+    test "update already in progress", %{state: state} do
+      state = %{state | status: {:updating, 20}}
+
+      # State is unchanged, effectively ignored
+      assert {:reply, _, ^state} =
+               UpdateManager.handle_call(
+                 {:apply_update, %{"firmware_url" => ""}},
+                 nil,
+                 state
+               )
+    end
+  end
+
+  describe "handle_info" do
+    test "fwup", %{state: state} do
+      message = {:ok, 1, "message"}
+      Mox.expect(ClientMock, :handle_fwup_message, fn ^message -> :ok end)
+      assert UpdateManager.handle_info({:fwup, message}, state) == {:noreply, state}
+    end
+
+    test "http_error", %{state: state} do
+      error = "error"
+      Mox.expect(ClientMock, :handle_error, fn ^error -> :apply end)
+
+      assert UpdateManager.handle_info({:http_error, error}, state) ==
+               {:noreply, %UpdateManager.State{status: :update_failed}}
+    end
+
+    test "update_reschedule", %{state: state} do
+      data = %{"firmware_url" => ""}
+      Mox.expect(ClientMock, :update_available, fn ^data -> :apply end)
+
+      assert {:noreply, %UpdateManager.State{status: {:updating, 0}}} =
+               UpdateManager.handle_info({:update_reschedule, data}, state)
+    end
+  end
+
+  describe "handle_info - down" do
+    test "normal", %{state: state} do
+      assert {:noreply, state} =
+               UpdateManager.handle_info({:DOWN, :any, :process, :any, :normal}, state)
+    end
+
+    test "non-normal", %{state: state} do
+      Mox.expect(ClientMock, :handle_error, 1, fn _ -> :ok end)
+
+      assert {:noreply, %UpdateManager.State{status: :update_failed}} =
+               UpdateManager.handle_info({:DOWN, :any, :process, :any, :"non-normal"}, state)
+    end
+  end
+end


### PR DESCRIPTION
This is a start to detangling the update code from the device channel. The next step is to separate the fwup process from the http process. 