### PR TITLE
provisioning.conf is unused so remove it

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,6 @@
 defmodule NervesHubLink.MixProject do
   use Mix.Project
 
-  Application.put_env(
-    :nerves_hub_link,
-    :nerves_provisioning,
-    Path.expand("priv/provisioning.conf")
-  )
-
   def project do
     [
       app: :nerves_hub_link,
@@ -69,8 +63,7 @@ defmodule NervesHubLink.MixProject do
         "CHANGELOG.md",
         "LICENSE",
         "mix.exs",
-        "README.md",
-        "provisioning.conf"
+        "README.md"
       ]
     ]
   end

--- a/provisioning.conf
+++ b/provisioning.conf
@@ -1,3 +1,0 @@
-uboot_setenv(uboot-env, "nerves_hub_cert", "\${NERVES_HUB_CERT}")
-uboot_setenv(uboot-env, "nerves_hub_key", "\${NERVES_HUB_KEY}")
-uboot_setenv(uboot-env, "nerves_serial_number", "\${NERVES_SERIAL_NUMBER}")


### PR DESCRIPTION
This also fixes a build error when the path couldn't be expanded since
it was wrong.