### PR TITLE
Fix fwup progress printout

### DIFF
--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -12,7 +12,7 @@ defmodule NervesHubLink.Client.Default do
   def update_available(_), do: :apply
 
   @impl NervesHubLink.Client
-  def handle_fwup_message({:progress, percent}) when rem(percent, 25) == 0 do
+  def handle_fwup_message({:progress, percent}) do
     Logger.debug("FWUP PROG: #{percent}%")
   end
 


### PR DESCRIPTION
This gets rid of logs like this:

```
20:29:41.202 [warn]  Unknown FWUP message: {:progress, 54}
```