### PR TITLE
Pass fwup success message on following spec

### DIFF
--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -24,6 +24,10 @@ defmodule NervesHubLink.Client.Default do
     Logger.warn("FWUP WARN: #{message}")
   end
 
+  def handle_fwup_message({:ok, status, message}) do
+    Logger.info("FWUP SUCCESS: #{status} #{message}")
+  end
+
   def handle_fwup_message(fwup_message) do
     Logger.warn("Unknown FWUP message: #{inspect(fwup_message)}")
   end

--- a/lib/nerves_hub_link/device_channel.ex
+++ b/lib/nerves_hub_link/device_channel.ex
@@ -79,7 +79,7 @@ defmodule NervesHubLink.DeviceChannel do
     end
   end
 
-  def handle_info({:fwup, {:ok, 0, message}}, state) do
+  def handle_info({:fwup, {:ok, _status, _info} = message}, state) do
     Logger.info("[NervesHubLink] FWUP Finished")
     _ = Client.handle_fwup_message(message)
     Nerves.Runtime.reboot()

--- a/test/nerves_hub_link/client/default_test.exs
+++ b/test/nerves_hub_link/client/default_test.exs
@@ -21,6 +21,10 @@ defmodule NervesHubLink.Client.DefaultTest do
       assert Default.handle_fwup_message({:warning, :any, "message"}) == :ok
     end
 
+    test "completion" do
+      assert Default.handle_fwup_message({:ok, 0, "success"}) == :ok
+    end
+
     test "any" do
       assert Default.handle_fwup_message(:any) == :ok
     end


### PR DESCRIPTION
The final fwup success message was being trimmed and reported as `""`.
It seems like Dialyzer should have caught this, but this change fixes
it. The log should now say:

```
21:33:06.315 [info]  FWUP SUCCESS: 0
```

When fwup is done instead of reporting an unknown empty message.