### PR TITLE
Fix UpdateManager calling `handle_fwup_message` on fwup success

### DIFF
--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -47,9 +47,9 @@ defmodule NervesHubLink.UpdateManager do
     {:reply, status, state}
   end
 
-  def handle_info({:fwup, {:ok, 0, message}}, state) do
+  def handle_info({:fwup, {:ok, 0, _message} = full_message}, state) do
     Logger.info("[NervesHubLink] FWUP Finished")
-    _ = Client.handle_fwup_message(message)
+    _ = Client.handle_fwup_message(full_message)
     Nerves.Runtime.reboot()
     {:noreply, state}
   end


### PR DESCRIPTION
UpdateManager was calling `handle_fwup_message` with `string()`
instead of the tuple `{:ok, 0, string()}`. This looks like a
bug because the default client does not have a handler for
`handle_fwup_message(string())`. Instead the default handler
is called and a warning message is logged during successful
firmware update.

=====

I was also looking at adding a test for this but Nerves.Runtime.reboot() kills off testing unless we want to make this a mockable behaviour. But while looking at testing I noticed the existing handle_info::fwup test (https://github.com/nerves-hub/nerves_hub_link/blob/master/test/nerves_hub_link/update_manager_test.exs#L93) does not actually test what it looks like it is testing. For example if you change the expected message in the test or break the implementation the test will still pass. This is because the Client module ignores all exceptions generated by the client implementation (https://github.com/nerves-hub/nerves_hub_link/blob/master/lib/nerves_hub_link/client.ex#L126). So if your mock is asserting that the message is equal to some expected message then it will throw an exception if it is wrong but the exception will just be ignored. I think this might apply to all the tests that are doing: `Mox.expect(ClientMock`