### PR TITLE
Keep Console API version separate

### DIFF
--- a/lib/nerves_hub_link/console_channel.ex
+++ b/lib/nerves_hub_link/console_channel.ex
@@ -35,7 +35,7 @@ defmodule NervesHubLink.ConsoleChannel do
 
   @rejoin_after Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
 
-  @version Mix.Project.config()[:version]
+  @version "1.0.0"
 
   defmodule State do
     defstruct socket: nil,


### PR DESCRIPTION
After some thought (and offline conv with @fhunleth), we decided it's best to keep the console API version separate from the library.

NervesHubWeb is looking for `>= 0.9.0`, so let's just start at `1.0.0`