### PR TITLE
Fix unmatched_returns found by Dialyzer

### DIFF
--- a/lib/nerves_hub_link/http_fwup_stream.ex
+++ b/lib/nerves_hub_link/http_fwup_stream.ex
@@ -51,7 +51,7 @@ defmodule NervesHubLink.HTTPFwupStream do
 
   @impl true
   def init([cb]) do
-    start_httpc()
+    _ = start_httpc()
 
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     args = ["--apply", "--no-unmount", "-d", devpath, "--task", "upgrade"]

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -116,7 +116,7 @@ defmodule NervesHubLink.UpdateManager do
     case Client.update_available(data) do
       :apply ->
         {:ok, http} = HTTPFwupStream.start(self())
-        spawn_monitor(HTTPFwupStream, :get, [http, url])
+        _ = spawn_monitor(HTTPFwupStream, :get, [http, url])
         Logger.info("[NervesHubLink] Downloading firmware: #{url}")
         %{state | status: {:updating, 0}}
 
@@ -135,9 +135,7 @@ defmodule NervesHubLink.UpdateManager do
   defp maybe_cancel_timer(%{update_reschedule_timer: nil} = state), do: state
 
   defp maybe_cancel_timer(%{update_reschedule_timer: timer} = state) do
-    if Process.read_timer(timer) do
-      Process.cancel_timer(timer)
-    end
+    _ = Process.cancel_timer(timer)
 
     %{state | update_reschedule_timer: nil}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -54,8 +54,7 @@ defmodule NervesHubLink.MixProject do
 
   defp dialyzer() do
     [
-      # TODO: add :unmatched_returns
-      flags: [:race_conditions, :error_handling, :underspecs],
+      flags: [:race_conditions, :error_handling, :underspecs, :unmatched_returns],
       plt_add_apps: [:atecc508a, :nerves_key, :nerves_key_pkcs11],
       list_unused_filters: true
     ]


### PR DESCRIPTION
According to the docs, `Process.cancel_timer/1` can be called on expired
timers, so there's no need to call `Process.read_timer/1`. It seems like
this wouldn't do any good anyway, since the timer could expire between
the call to `read_timer/1` and `cancel_timer/1` anyway.