### PR TITLE
Report fwup version to nerves hub

### DIFF
--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -48,7 +48,7 @@ defmodule NervesHubLink.Configurator do
       |> Keyword.put_new(:verify, :verify_peer)
       |> Keyword.put_new(:server_name_indication, to_charlist(base.device_api_sni))
 
-    params = Map.put(Nerves.Runtime.KV.get_all_active(), "nerves_fw_fwup_version", fwup_version())
+    params = Map.put(Nerves.Runtime.KV.get_all_active(), "fwup_version", fwup_version())
 
     %{base | params: params, socket: socket, ssl: ssl}
   end
@@ -76,6 +76,6 @@ defmodule NervesHubLink.Configurator do
 
   defp fwup_version do
     {version_string, 0} = System.cmd("fwup", ["--version"])
-    version_string |> String.trim()
+    String.trim(version_string)
   end
 end

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -48,7 +48,9 @@ defmodule NervesHubLink.Configurator do
       |> Keyword.put_new(:verify, :verify_peer)
       |> Keyword.put_new(:server_name_indication, to_charlist(base.device_api_sni))
 
-    %{base | params: Nerves.Runtime.KV.get_all_active(), socket: socket, ssl: ssl}
+    params = Map.put(Nerves.Runtime.KV.get_all_active(), "nerves_fw_fwup_version", fwup_version())
+
+    %{base | params: params, socket: socket, ssl: ssl}
   end
 
   defp do_build(configurator) when is_atom(configurator) do
@@ -70,5 +72,10 @@ defmodule NervesHubLink.Configurator do
     else
       Default
     end
+  end
+
+  defp fwup_version do
+    {version_string, 0} = System.cmd("fwup", ["--version"])
+    version_string |> String.trim()
   end
 end

--- a/test/nerves_hub_link/configurator_test.exs
+++ b/test/nerves_hub_link/configurator_test.exs
@@ -18,6 +18,6 @@ defmodule NervesHubLink.ConfiguratorTest do
 
   test "fwup_version is included in params" do
     config = NervesHubLink.Configurator.build()
-    assert Map.has_key?(config.params, "nerves_fw_fwup_version")
+    assert Map.has_key?(config.params, "fwup_version")
   end
 end

--- a/test/nerves_hub_link/configurator_test.exs
+++ b/test/nerves_hub_link/configurator_test.exs
@@ -15,4 +15,9 @@ defmodule NervesHubLink.ConfiguratorTest do
     config = NervesHubLink.Configurator.build()
     assert config.socket[:transport_opts][:socket_opts] == ssl
   end
+
+  test "fwup_version is included in params" do
+    config = NervesHubLink.Configurator.build()
+    assert Map.has_key?(config.params, "nerves_fw_fwup_version")
+  end
 end


### PR DESCRIPTION
Why:

* NH needs to know the fwup version to make decisions about delta updates
* Resolves Issue #43

This change addresses the need by:

* Grab fwup version when creating config
* Add fwup version to config params
* Add a spec to check that fwup version key is present