### PR TITLE
Handle :window_size message (#46)

### DIFF
--- a/lib/nerves_hub_link/console_channel.ex
+++ b/lib/nerves_hub_link/console_channel.ex
@@ -94,6 +94,11 @@ defmodule NervesHubLink.ConsoleChannel do
     {:noreply, state, iex_timeout()}
   end
 
+  def handle_info(%Message{event: "window_size", payload: %{"height" => height, "width" => width}}, state) do
+    ExTTY.window_change(state.iex_pid, width, height)
+    {:noreply, state}
+  end
+
   def handle_info(%Message{event: event, payload: payload}, state)
       when event in ["phx_error", "phx_close"] do
     reason = Map.get(payload, :reason, "unknown")

--- a/test/nerves_hub_link/console_channel_test.exs
+++ b/test/nerves_hub_link/console_channel_test.exs
@@ -22,6 +22,14 @@ defmodule NervesHubLink.ConsoleChannelTest do
       assert new_state.iex_pid != state.iex_pid
     end
 
+    test "window_size - sets width & height of ExTTY", %{state: state} do
+      {:ok, iex_pid} = ExTTY.start_link(handler: self(), type: :elixir)
+      state = %{state | iex_pid: iex_pid}
+      msg = %Message{event: "window_size", payload: %{"height" => 200, "width" => 300}}
+
+      assert {:noreply, state} == ConsoleChannel.handle_info(msg, state)
+    end
+
     test "dn - sends text to ExTTY", %{state: state} do
       {:ok, iex_pid} = ExTTY.start_link(handler: self(), type: :elixir)
       state = %{state | iex_pid: iex_pid}


### PR DESCRIPTION
I'm having issues running the tests locally at the moment. 

I was hoping of doing an assert via. Any ideas? 
```elixir
assert_receive {:tty_data, "\e[33m\e[36mSome message about changing window size\e[0m\e[33m\e[0m\r\n"}
```