### PR TITLE
Fix console window resize error message

### DIFF
--- a/lib/nerves_hub_link/console_channel.ex
+++ b/lib/nerves_hub_link/console_channel.ex
@@ -94,6 +94,14 @@ defmodule NervesHubLink.ConsoleChannel do
     {:noreply, state, iex_timeout()}
   end
 
+  def handle_info(
+        %Message{event: "window_size", payload: %{"width" => width, "height" => height}},
+        state
+      ) do
+    ExTTY.window_change(state.iex_pid, width, height)
+    {:noreply, state, iex_timeout()}
+  end
+
   def handle_info(%Message{event: event, payload: payload}, state)
       when event in ["phx_error", "phx_close"] do
     reason = Map.get(payload, :reason, "unknown")


### PR DESCRIPTION
fixes this annoying log message: 
```
20:30:36.704 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 62, \"width\" => 164}, ref: nil, topic: \"console\"}"
20:30:37.070 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 59, \"width\" => 152}, ref: nil, topic: \"console\"}"
20:30:37.074 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 56, \"width\" => 143}, ref: nil, topic: \"console\"}"
20:30:37.207 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 52, \"width\" => 130}, ref: nil, topic: \"console\"}"
20:30:37.213 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 50, \"width\" => 125}, ref: nil, topic: \"console\"}"
20:30:37.221 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 50, \"width\" => 125}, ref: nil, topic: \"console\"}"
20:30:37.620 [warn]  Firmware stream error: "Unhandled Console handle_info - %PhoenixClient.Message{channel_pid: #PID<0.2554.0>, event: \"window_size\", join_ref: nil, payload: %{\"height\" => 49, \"width\" => 125}, ref: nil, topic: \"console\"}"
```