### PR TITLE
change default error message

### DIFF
--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -34,6 +34,6 @@ defmodule NervesHubLink.Client.Default do
 
   @impl NervesHubLink.Client
   def handle_error(error) do
-    Logger.warn("Firmware stream error: #{inspect(error)}")
+    Logger.warn("[NervesHubLink] error: #{inspect(error)}")
   end
 end


### PR DESCRIPTION
`Client.handle_error` is called in multiple places so it doesn't make sense to make the default error say `"Firmware stream error"`

This changes that to scope to `NervesHubLink`