### PR TITLE
Check firmware_url is valid before attempting update

### DIFF
--- a/lib/nerves_hub_link/device_channel.ex
+++ b/lib/nerves_hub_link/device_channel.ex
@@ -106,7 +106,7 @@ defmodule NervesHubLink.DeviceChannel do
   @impl GenServer
   def terminate(_reason, _state), do: NervesHubLink.Connection.disconnected()
 
-  defp handle_join_reply(%{"firmware_url" => _url} = update) do
+  defp handle_join_reply(%{"firmware_url" => url} = update) when is_binary(url) do
     UpdateManager.apply_update(update)
   end
 


### PR DESCRIPTION
If NervesHub were to send an empty firmware_url, the device would crash
in a very descructive way and stop `:nerves_hub_link`

This checks the firmware url is actually there before attempting an
update to avoid such calamity