### PR TITLE
Fix timeout when reconnecting

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -111,14 +111,9 @@ defmodule NervesHubLink.Socket do
 
   @impl Slipstream
   def handle_cast(:reconnect, socket) do
-    {:ok, socket} =
-      socket
-      |> disconnect()
-      |> await_disconnect()
-
-    {:ok, socket} = reconnect(socket)
-
-    {:noreply, socket}
+    # See handle_disconnect/2 for the reconnect call once the connection is
+    # closed.
+    {:noreply, disconnect(socket)}
   end
 
   def handle_cast({:send_update_progress, progress}, socket) do


### PR DESCRIPTION
This removes an unnecessary synchronous call to await_disconnect that
would time out when there wasn't a connection to disconnect. The easier
way to handle this is to not bother waiting at all and let the
reconnection logic work.

This looks funny so I left a note. This fixes the exception that was
being thrown when timing out and it reconnects properly when reconnect
is called both when there's a connection and not.
