### PR TITLE
Start an iex session if window_size is sent first

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -166,8 +166,8 @@ defmodule NervesHubLink.Socket do
     {:ok, set_iex_timer(socket)}
   end
 
-  def handle_message(@console_topic, "dn", payload, %{assigns: %{iex_pid: nil}} = socket) do
-    handle_message(@console_topic, "dn", payload, start_iex(socket))
+  def handle_message(@console_topic, message, payload, %{assigns: %{iex_pid: nil}} = socket) do
+    handle_message(@console_topic, message, payload, start_iex(socket))
   end
 
   def handle_message(@console_topic, "dn", %{"data" => data}, socket) do


### PR DESCRIPTION
This fixes this process exit.

```
21:37:21.740 [error] GenServer NervesHubLink.Socket terminating
** (stop) exited in: GenServer.call(nil, {:window_change, 157, 44}, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.12.3) lib/gen_server.ex:1014: GenServer.call/3
    (nerves_hub_link 1.0.0) lib/nerves_hub_link/socket.ex:184: NervesHubLink.Socket.handle_message/4
```
