### PR TITLE
Use `Slipstream.push/5` for safe publishing

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -118,12 +118,12 @@ defmodule NervesHubLink.Socket do
   end
 
   def handle_cast({:send_update_progress, progress}, socket) do
-    _ = push!(socket, @device_topic, "fwup_progress", %{value: progress})
+    _ = push(socket, @device_topic, "fwup_progress", %{value: progress})
     {:noreply, socket}
   end
 
   def handle_cast({:send_update_status, status}, socket) do
-    _ = push!(socket, @device_topic, "status_update", %{status: status})
+    _ = push(socket, @device_topic, "status_update", %{status: status})
     {:noreply, socket}
   end
 
@@ -133,7 +133,7 @@ defmodule NervesHubLink.Socket do
   #
   def handle_message(@device_topic, "reboot", _params, socket) do
     Logger.warn("Reboot Request from NervesHubLink")
-    _ = push!(socket, @device_topic, "rebooting", %{})
+    _ = push(socket, @device_topic, "rebooting", %{})
     # TODO: Maybe allow delayed reboot
     Nerves.Runtime.reboot()
     {:ok, socket}
@@ -157,7 +157,7 @@ defmodule NervesHubLink.Socket do
   def handle_message(@console_topic, "restart", _payload, socket) do
     Logger.warn("[#{inspect(__MODULE__)}] Restarting IEx process from web request")
 
-    _ = push!(socket, @console_topic, "up", %{data: "\r*** Restarting IEx ***\r"})
+    _ = push(socket, @console_topic, "up", %{data: "\r*** Restarting IEx ***\r"})
 
     socket =
       socket
@@ -188,13 +188,13 @@ defmodule NervesHubLink.Socket do
 
   @impl Slipstream
   def handle_info({:tty_data, data}, socket) do
-    _ = push!(socket, @console_topic, "up", %{data: data})
+    _ = push(socket, @console_topic, "up", %{data: data})
     {:noreply, set_iex_timer(socket)}
   end
 
   def handle_info({:EXIT, iex_pid, reason}, %{assigns: %{iex_pid: iex_pid}} = socket) do
     msg = "\r******* Remote IEx stopped: #{inspect(reason)} *******\r"
-    _ = push!(socket, @console_topic, "up", %{data: msg})
+    _ = push(socket, @console_topic, "up", %{data: msg})
     Logger.warn(msg)
 
     socket =
@@ -215,7 +215,7 @@ defmodule NervesHubLink.Socket do
     ****************************************\r
     """
 
-    _ = push!(socket, @console_topic, "up", %{data: msg})
+    _ = push(socket, @console_topic, "up", %{data: msg})
 
     {:noreply, stop_iex(socket)}
   end


### PR DESCRIPTION
We've recently run into a condition where another failure caused the socket to
crash, but `fwup` was still applying an update sending messages to new socket
process which hadn't joined the channel yet. `push!/4` would then crash
the socket again and repeat the cycle.

In most cases, these messages are not critical so switch to the safe `push/5`
version, we can avoid needless crashes and still be okay on the web side