### PR TITLE
Don't apply update by default if the UUID is the same

### DIFF
--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -39,7 +39,7 @@ defmodule NervesHubLink.Client do
   require Logger
 
   @typedoc "Update that comes over a socket."
-  @type update_data :: map()
+  @type update_data :: NervesHubLinkCommon.Message.UpdateInfo.t()
 
   @typedoc "Supported responses from `update_available/1`"
   @type update_response :: :apply | :ignore | {:reschedule, pos_integer()}

--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -9,7 +9,19 @@ defmodule NervesHubLink.Client.Default do
   require Logger
 
   @impl NervesHubLink.Client
-  def update_available(_), do: :apply
+  def update_available(update_info) do
+    if update_info.firmware_meta.uuid == Nerves.Runtime.KV.get_active("nerves_fw_uuid") do
+      Logger.info("""
+      [NervesHubLink.Client] Ignoring request to update to the same firmware
+
+      #{inspect(update_info)}
+      """)
+
+      :ignore
+    else
+      :apply
+    end
+  end
 
   @impl NervesHubLink.Client
   def handle_fwup_message({:progress, percent}) do

--- a/test/nerves_hub_link/client/default_test.exs
+++ b/test/nerves_hub_link/client/default_test.exs
@@ -1,11 +1,26 @@
 defmodule NervesHubLink.Client.DefaultTest do
   use ExUnit.Case, async: true
   alias NervesHubLink.Client.Default
+  alias NervesHubLinkCommon.Message.{FirmwareMetadata, UpdateInfo}
+
+  import ExUnit.CaptureIO
 
   doctest Default
 
+  @update_info %UpdateInfo{
+    firmware_url: "https://nerves-hub.org/firmware/1234",
+    firmware_meta: %FirmwareMetadata{}
+  }
+
   test "update_available/1" do
-    assert Default.update_available(-1) == :apply
+    assert Default.update_available(@update_info) == :apply
+  end
+
+  test "update_avialable with same uuid" do
+    update_info =
+      put_in(@update_info.firmware_meta.uuid, Nerves.Runtime.KV.get_active("nerves_fw_uuid"))
+
+    assert Default.update_available(update_info) == :ignore
   end
 
   describe "handle_fwup_message/1" do


### PR DESCRIPTION
This is to help handle an edge case where (for whatever reason) the NervesHub
server may send a second update request despite the device already having
updated. In that case, if the request is the same UUID of the currently running
firmware, then we ignore the request and log it