### PR TITLE
Stop IEx process with :normal instead of 10_000

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -299,7 +299,7 @@ defmodule NervesHubLink.Socket do
 
   defp stop_iex(%{assigns: %{iex_pid: iex}} = socket) do
     _ = Process.unlink(iex)
-    :ok = GenServer.stop(iex, 10_000)
+    :ok = GenServer.stop(iex, :normal)
     assign(socket, iex_pid: nil)
   end
 end


### PR DESCRIPTION
Unless there's a reason to stop the IEx process with a non-normal status, this seems like it was probably an oversight.