### PR TITLE
Expose whether an IEx session is active or not

### DIFF
--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -21,6 +21,12 @@ defmodule NervesHubLink do
   end
 
   @doc """
+  Return whether there's currently an active console session
+  """
+  @spec console_active?() :: boolean()
+  defdelegate console_active?, to: Socket
+
+  @doc """
   Current status of the update manager
   """
   @spec status :: NervesHubLinkCommon.UpdateManager.State.status()

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -1,4 +1,6 @@
 defmodule NervesHubLink.Socket do
+  @moduledoc false
+
   use Slipstream
   require Logger
 
@@ -42,6 +44,14 @@ defmodule NervesHubLink.Socket do
 
   def check_connection(type) do
     GenServer.call(__MODULE__, {:check_connection, type})
+  end
+
+  @doc """
+  Return whether an IEx or other console session is active
+  """
+  @spec console_active?() :: boolean()
+  def console_active?() do
+    GenServer.call(__MODULE__, :console_active?)
   end
 
   @impl Slipstream
@@ -108,6 +118,10 @@ defmodule NervesHubLink.Socket do
 
   def handle_call({:check_connection, :socket}, _from, socket) do
     {:reply, connected?(socket), socket}
+  end
+
+  def handle_call(:console_active?, _from, socket) do
+    {:reply, socket.assigns.iex_pid != nil, socket}
   end
 
   @impl Slipstream


### PR DESCRIPTION
This is useful for avoiding operations that affect remote debug of a
device when someone is actively debugging. For example, this makes it
possible to avoid upgrading the NervesHub connection to what looks like
a better network interface, but actually isn't.
