### PR TITLE
ArchiveManager to handle NervesHub sending extra firmware

### DIFF
--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -1,6 +1,7 @@
 defmodule NervesHubLink.Application do
   use Application
 
+  alias NervesHubLink.ArchiveManager
   alias NervesHubLink.Client
   alias NervesHubLink.Configurator
   alias NervesHubLink.Socket
@@ -28,6 +29,7 @@ defmodule NervesHubLink.Application do
   defp children(config, fwup_config) do
     [
       {UpdateManager, fwup_config},
+      {ArchiveManager, config},
       {Socket, config}
     ]
   end

--- a/lib/nerves_hub_link/archive_manager.ex
+++ b/lib/nerves_hub_link/archive_manager.ex
@@ -1,0 +1,178 @@
+defmodule NervesHubLink.ArchiveManager do
+  @moduledoc """
+  GenServer for handling downloading archives from NervesHub
+
+  Your NervesHubLink client will tell the manager when to download
+  an archive and the Manager will tell your client when it's done
+  downloading so you can act on it.
+
+  You are expected to remove the file when you're done with it and track
+  that it has been applied to prevent downloading again.
+  """
+
+  use GenServer
+
+  alias NervesHubLink.Client
+  alias NervesHubLink.Downloader
+  alias NervesHubLink.Message.ArchiveInfo
+
+  require Logger
+
+  @type status :: :idle | :downloading | :done | :update_rescheduled
+
+  @type t :: %__MODULE__{
+          archive_info: nil | ArchiveInfo.t(),
+          data_path: Path.t(),
+          download: nil | GenServer.server(),
+          file_path: Path.t(),
+          status: status(),
+          update_reschedule_timer: nil | :timer.tref()
+        }
+
+  defstruct archive_info: nil,
+            data_path: nil,
+            download: nil,
+            file_path: nil,
+            status: :idle,
+            update_reschedule_timer: nil
+
+  @doc """
+  Must be called when an archive payload is dispatched from
+  NervesHub. the map must contain a `"url"` key.
+  """
+  @spec apply_archive(GenServer.server(), ArchiveInfo.t()) :: status()
+  def apply_archive(manager \\ __MODULE__, %ArchiveInfo{} = archive_info) do
+    GenServer.call(manager, {:apply_archive, archive_info})
+  end
+
+  @doc """
+  Returns the current status of the archive manager
+  """
+  @spec status(GenServer.server()) :: status()
+  def status(manager \\ __MODULE__) do
+    GenServer.call(manager, :status)
+  end
+
+  @doc """
+  Returns the UUID of the currently downloading archive, or nil.
+  """
+  @spec currently_downloading_uuid(GenServer.server()) :: uuid :: String.t() | nil
+  def currently_downloading_uuid(manager \\ __MODULE__) do
+    GenServer.call(manager, :currently_downloading_uuid)
+  end
+
+  @doc false
+  @spec child_spec(map()) :: Supervisor.child_spec()
+  def child_spec(args) do
+    %{
+      start: {__MODULE__, :start_link, [args, [name: __MODULE__]]},
+      id: __MODULE__
+    }
+  end
+
+  @doc false
+  @spec start_link(GenServer.options()) :: GenServer.on_start()
+  def start_link(args, opts \\ []) do
+    GenServer.start_link(__MODULE__, args, opts)
+  end
+
+  @impl GenServer
+  def init(args) do
+    {:ok, %__MODULE__{data_path: args.data_path}}
+  end
+
+  @impl GenServer
+  def handle_call({:apply_archive, %ArchiveInfo{} = info}, _from, %__MODULE__{} = state) do
+    state = maybe_update_archive(info, state)
+    {:reply, state.status, state}
+  end
+
+  def handle_call(:currently_downloading_uuid, _from, %__MODULE__{archive_info: nil} = state) do
+    {:reply, nil, state}
+  end
+
+  def handle_call(:currently_downloading_uuid, _from, %__MODULE__{} = state) do
+    {:reply, state.archive_info.uuid, state}
+  end
+
+  def handle_call(:status, _from, %__MODULE__{} = state) do
+    {:reply, state.status, state}
+  end
+
+  @impl GenServer
+  def handle_info({:update_reschedule, response}, state) do
+    {:noreply, maybe_update_archive(response, %__MODULE__{state | update_reschedule_timer: nil})}
+  end
+
+  # messages from Downloader
+  def handle_info({:download, :complete}, state) do
+    Logger.info("[NervesHubLink] Archive Download complete")
+    _ = Client.archive_ready(state.archive_info, state.file_path)
+
+    {:noreply,
+     %__MODULE__{state | archive_info: nil, file_path: nil, download: nil, status: :idle}}
+  end
+
+  def handle_info({:download, {:error, reason}}, state) do
+    Logger.error("[NervesHubLink] Nonfatal HTTP download error: #{inspect(reason)}")
+    {:noreply, state}
+  end
+
+  # Data from the downloader
+  def handle_info({:download, {:data, data}}, state) do
+    :ok =
+      File.open!(state.file_path, [:append], fn fd ->
+        IO.binwrite(fd, data)
+      end)
+
+    {:noreply, state}
+  end
+
+  defp maybe_update_archive(info, state) do
+    # Cancel an existing timer if it exists.
+    # This prevents rescheduled updates`
+    # from compounding.
+    state = maybe_cancel_timer(state)
+
+    uri = URI.parse(info.url)
+    file_name = Path.basename(uri.path)
+    file_path = Path.join(state.data_path, "archives/#{file_name}")
+    directory = Path.dirname(file_path)
+
+    pid = self()
+
+    case Client.archive_available(info) do
+      :download ->
+        {:ok, download} = Downloader.start_download(info.url, &send(pid, {:download, &1}))
+
+        _ = File.mkdir_p(directory)
+        # delete the old one in case it was a failed download
+        _ = File.rm_rf(file_path)
+        _ = File.touch(file_path)
+
+        %__MODULE__{
+          state
+          | archive_info: info,
+            file_path: file_path,
+            download: download,
+            status: :downloading
+        }
+
+      :ignore ->
+        state
+
+      {:reschedule, ms} ->
+        timer = Process.send_after(self(), {:update_reschedule, info}, ms)
+        Logger.info("[NervesHubLink] rescheduling archive in #{ms} milliseconds")
+        %{state | status: :update_rescheduled, update_reschedule_timer: timer}
+    end
+  end
+
+  defp maybe_cancel_timer(%{update_reschedule_timer: nil} = state), do: state
+
+  defp maybe_cancel_timer(%{update_reschedule_timer: timer} = state) do
+    _ = Process.cancel_timer(timer)
+
+    %{state | update_reschedule_timer: nil}
+  end
+end

--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -24,6 +24,24 @@ defmodule NervesHubLink.Client.Default do
   end
 
   @impl NervesHubLink.Client
+  def archive_available(archive_info) do
+    Logger.info(
+      "[NervesHubLink.Client] Archive is available for downloading #{inspect(archive_info)}"
+    )
+
+    :ignore
+  end
+
+  @impl NervesHubLink.Client
+  def archive_ready(archive_info, file_path) do
+    Logger.info(
+      "[NervesHubLink.Client] Archive is ready for processing #{inspect(archive_info)} at #{inspect(file_path)}"
+    )
+
+    :ok
+  end
+
+  @impl NervesHubLink.Client
   def handle_fwup_message({:progress, percent}) do
     Logger.debug("FWUP PROG: #{percent}%")
   end

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -3,7 +3,7 @@ defmodule NervesHubLink.Configurator do
   alias __MODULE__.{Config, Default}
   require Logger
 
-  @device_api_version "1.0.0"
+  @device_api_version "2.0.0"
   @console_version "2.0.0"
 
   defmodule Config do

--- a/lib/nerves_hub_link/message/archive_info.ex
+++ b/lib/nerves_hub_link/message/archive_info.ex
@@ -1,0 +1,44 @@
+defmodule NervesHubLink.Message.ArchiveInfo do
+  @moduledoc false
+
+  defstruct [
+    :architecture,
+    :description,
+    :platform,
+    :size,
+    :uploaded_at,
+    :url,
+    :uuid,
+    :version
+  ]
+
+  @typedoc """
+  Payload that gets dispatched down to devices upon an archive being available
+  """
+  @type t() :: %__MODULE__{
+          architecture: String.t(),
+          description: String.t(),
+          platform: String.t(),
+          size: integer(),
+          uploaded_at: DateTime.t(),
+          url: URI.t(),
+          uuid: String.t(),
+          version: Version.t()
+        }
+
+  @doc "Parse an update message from NervesHub"
+  @spec parse(map()) :: {:ok, t()}
+  def parse(params) do
+    {:ok,
+     %__MODULE__{
+       architecture: params["architecture"],
+       description: params["description"],
+       platform: params["platform"],
+       size: params["size"],
+       uploaded_at: params["uploaded_at"],
+       uuid: params["uuid"],
+       url: params["url"],
+       version: params["version"]
+     }}
+  end
+end

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -5,6 +5,7 @@ defmodule NervesHubLink.Socket do
 
   require Logger
 
+  alias NervesHubLink.ArchiveManager
   alias NervesHubLink.Client
   alias NervesHubLink.Configurator.SharedSecret
   alias NervesHubLink.UpdateManager
@@ -255,6 +256,12 @@ defmodule NervesHubLink.Socket do
 
   def handle_message(@device_topic, "identify", _params, socket) do
     Client.identify()
+    {:ok, socket}
+  end
+
+  def handle_message(@device_topic, "archive", params, socket) do
+    {:ok, info} = NervesHubLink.Message.ArchiveInfo.parse(params)
+    _ = ArchiveManager.apply_archive(info)
     {:ok, socket}
   end
 


### PR DESCRIPTION
Archives are an extra firmware attached to a deployment. On connect NervesHub will potentially send a message about an archive and the device can download the firmware to a configured / known location and tell the configured client that it's there. ArchiveManager does nothing else as the extra firmware will be highly application specific.

Related: https://github.com/nerves-hub/nerves_hub_web/pull/1091