### PR TITLE
Pre-shared key authentication

### DIFF
--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -1,0 +1,72 @@
+defmodule NervesHubLink.Configurator.SharedSecret do
+  @behaviour NervesHubLink.Configurator
+
+  alias NervesHubLink.Certificate
+  alias NervesHubLink.Configurator.Config
+
+  @impl NervesHubLink.Configurator
+  def build(%Config{ssl: ssl, socket: socket} = config) do
+    ssl =
+      ssl
+      |> Keyword.drop([:key, :cert])
+      |> Keyword.put_new(:cacerts, Certificate.ca_certs())
+
+    # Shared Secret Auth uses a different socket path
+    url = URI.merge(socket[:url], "/device-socket/websocket") |> to_string()
+
+    %{config | ssl: ssl, socket: Keyword.merge(socket, headers: headers(config), url: url)}
+  end
+
+  @doc """
+  Generate headers for Shared Secret Auth
+  """
+  @spec headers(Config.t()) :: [{String.t(), String.t()}]
+  def headers(%{socket: socket}) do
+    opts =
+      (socket[:shared_secret] || [])
+      |> Keyword.put_new(:key_digest, :sha256)
+      |> Keyword.put_new(:key_iterations, 1000)
+      |> Keyword.put_new(:key_length, 32)
+      |> Keyword.put_new(:signature_version, "NH1")
+      |> Keyword.put_new(:identifier, Nerves.Runtime.serial_number())
+      |> Keyword.put(:signed_at, System.system_time(:second))
+
+    alg =
+      "#{opts[:signature_version]}-HMAC-#{opts[:key_digest]}-#{opts[:key_iterations]}-#{opts[:key_length]}"
+
+    # Lookup device first then product
+    # TODO: Support saving to file?
+    key =
+      Nerves.Runtime.KV.get("nh_shared_key") || opts[:key] ||
+        Nerves.Runtime.KV.get("nh_shared_product_key") || opts[:product_key]
+
+    secret =
+      case key do
+        "nhp_" <> _ ->
+          Nerves.Runtime.KV.get("nh_shared_product_secret") || opts[:product_secret]
+
+        _ ->
+          Nerves.Runtime.KV.get("nh_shared_secret") || opts[:secret]
+      end
+
+    salt = create_salt(opts[:signature_version], alg, key, opts[:signed_at])
+
+    [
+      {"x-nh-alg", alg},
+      {"x-nh-key", key},
+      {"x-nh-time", to_string(opts[:signed_at])},
+      {"x-nh-signature", Plug.Crypto.sign(secret, salt, opts[:identifier], opts)}
+    ]
+  end
+
+  # Currently only support NH1
+  defp create_salt(_NH1, alg, key, time) do
+    """
+    NH1:device-socket:shared-secret:connect
+
+    x-nh-alg=#{alg}
+    x-nh-key=#{key}
+    x-nh-time=#{time}
+    """
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -103,6 +103,7 @@ defmodule NervesHubLink.MixProject do
       {:mox, "~> 1.0", only: :test},
       {:nerves_key, "~> 1.0 or ~> 0.5", optional: true},
       {:nerves_runtime, "~> 0.8"},
+      {:plug_crypto, "~> 2.0"},
       {:plug_cowboy, "~> 2.0", only: :test},
       {:slipstream, "~> 1.0 or ~> 0.8"},
       {:x509, "~> 0.5"}


### PR DESCRIPTION
Initial stub for testing PSK auth.

Requires https://github.com/nerves-hub/nerves_hub_web/pull/1139

Test configuration:

```elixir
config :nerves_hub_link,
  configurator: NervesHubLink.Configurator.SharedSecret,
  socket: [
    shared_secret: [
      product_key: "<your-product-key>",
      product_secret: "<your-product-secret>,
      identifier: "<some-identifier>" # Remove for Nerves.Runtime.serial_number()
    ],
    url: "ws://<your-host>:<your-port>/device-socket/websocket"
  ]
```