### PR TITLE
support nerveshub sending current fwup public keys

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -246,6 +246,14 @@ defmodule NervesHubLink.Socket do
   ##
   # Device API messages
   #
+  def handle_message(@device_topic, "fwup_public_keys", params, socket) do
+    Logger.info("Updating fwup public keys from NervesHubLink - #{Enum.count(params["keys"])} key(s) received")
+
+    config = %{socket.assigns.config | fwup_public_keys: params["keys"]}
+
+    {:ok, assign(socket, config: config)}
+  end
+
   def handle_message(@device_topic, "reboot", _params, socket) do
     Logger.warning("Reboot Request from NervesHubLink")
     _ = push(socket, @device_topic, "rebooting", %{})


### PR DESCRIPTION
when the device connects it can now request all current fwup public keys are sent down the wire.

here is the general logic:

1. if there are no firmware signing keys configured on the device then it should request them when connecting
2. if 1 or more firmware signing keys are on the device, then it will not request any updated keys
3. keys can be requested during connection via an opt-in setting on the device
