### PR TITLE
Add a catch-all for messages from NervesHub

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -348,6 +348,15 @@ defmodule NervesHubLink.Socket do
     {:ok, socket}
   end
 
+  ##
+  # Unknown message
+  #
+  def handle_message(topic, event, _params, _socket) do
+    Logger.warning("Unknown message (\"#{topic}:#{event}\") received")
+
+    {:ok, socket}
+  end
+
   @impl Slipstream
   def handle_info({:tty_data, data}, socket) do
     _ = push(socket, @console_topic, "up", %{data: data})


### PR DESCRIPTION
this is useful for cases where `NervesHub` adds new features which `NervesHubLink` doesn't support yet