### PR TITLE
Have link wait some number of seconds before connecting

### DIFF
--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -8,6 +8,7 @@ defmodule NervesHubLink.Configurator do
 
   defmodule Config do
     defstruct connect: true,
+              connect_wait: 15_000,
               data_path: "/data/nerves-hub",
               device_api_host: nil,
               device_api_port: 443,
@@ -25,6 +26,7 @@ defmodule NervesHubLink.Configurator do
 
     @type t() :: %__MODULE__{
             connect: boolean(),
+            connect_wait: integer(),
             data_path: Path.t(),
             device_api_host: String.t(),
             device_api_port: String.t(),


### PR DESCRIPTION
It usually takes 10-20 seconds for the network to become available after the device is started. 
This adds a 15-second delay and can be configured to whatever is preferred