### PR TITLE
have link check for network availability before connecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,14 +392,14 @@ config :nerves_hub_link, remote_iex_timeout: 900 # 15 minutes
 
 You may also need additional permissions on NervesHub to see the device and to use the remote IEx feature.
 
-### Alarms 
+### Alarms
 
 This application can set and clear the following alarms:
 
 * `NervesHubLink.Disconnected`
   * set: An issue is preventing a connection to NervesHub or one just hasn't been made yet
   * clear: Currently connected to NervesHub
-* `NervesHubLink.UpdateInProgress` 
+* `NervesHubLink.UpdateInProgress`
   * set: A new firmware update is being downloaded or applied
   * clear: No updates are happening
 
@@ -420,6 +420,16 @@ Or if you have the certificates in DER format, you can also explicitly set them 
 ```elixir
 my_der_list = [<<213, 34, 234, 53, 83, 8, 2, ...>>]
 config :nerves_hub_link, ssl: [cacerts: my_der_list]
+```
+
+### Verifying network availability
+
+`NervesHubLink` will attempt to verify that the network is available before initiating the first connection attempt. This is done by checking if the `NervesHub` host address (`config.device_api_host`) can be resolved. If the network isn't available then the check will be run again in 2 seconds.
+
+You can disable this behaviour with the following config:
+
+```elixir
+config :nerves_hub_link, connect_wait_for_network: false
 ```
 
 ## Debugging errors

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -8,6 +8,7 @@ defmodule NervesHubLink.Configurator do
 
   defmodule Config do
     defstruct connect: true,
+              connect_wait_for_network: true,
               data_path: "/data/nerves-hub",
               device_api_host: nil,
               device_api_port: 443,
@@ -25,6 +26,7 @@ defmodule NervesHubLink.Configurator do
 
     @type t() :: %__MODULE__{
             connect: boolean(),
+            connect_wait_for_network: boolean(),
             data_path: Path.t(),
             device_api_host: String.t(),
             device_api_port: String.t(),

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -91,15 +91,6 @@ defmodule NervesHubLink.Socket do
   @impl Slipstream
   def init(config) do
     :alarm_handler.set_alarm({NervesHubLink.Disconnected, []})
-    rejoin_after = Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
-
-    opts = [
-      mint_opts: [protocols: [:http1], transport_opts: config.ssl],
-      headers: config.socket[:headers] || [],
-      uri: config.socket[:url],
-      rejoin_after_msec: [rejoin_after],
-      reconnect_after_msec: config.socket[:reconnect_after_msec]
-    ]
 
     socket =
       new_socket()
@@ -113,15 +104,40 @@ defmodule NervesHubLink.Socket do
       |> assign(started_at: System.monotonic_time(:millisecond))
       |> assign(connected_at: nil)
       |> assign(joined_at: nil)
-      |> connect!(opts)
 
-    Process.flag(:trap_exit, true)
-
-    {:ok, socket}
+    if config.connect_wait_for_network do
+      schedule_network_availability_check()
+      {:ok, socket}
+    else
+      {:ok, socket, {:continue, :connect}}
+    end
   end
 
   @impl Slipstream
-  def handle_connect(socket) do
+  def handle_continue(:connect, %{assigns: %{config: config}} = socket) do
+    Logger.info("[NervesHubLink] connecting to #{config.device_api_host}")
+
+    rejoin_after = Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
+
+    opts = [
+      mint_opts: [protocols: [:http1], transport_opts: config.ssl],
+      headers: config.socket[:headers] || [],
+      uri: config.socket[:url],
+      rejoin_after_msec: [rejoin_after],
+      reconnect_after_msec: config.socket[:reconnect_after_msec]
+    ]
+
+    socket = connect!(socket, opts)
+
+    Process.flag(:trap_exit, true)
+
+    {:noreply, socket}
+  end
+
+  @impl Slipstream
+  def handle_connect(%{assigns: %{config: config}} = socket) do
+    Logger.info("[NervesHubLink] connection to #{config.device_api_host} succeeded")
+
     currently_downloading_uuid = UpdateManager.currently_downloading_uuid()
 
     device_join_params =
@@ -349,6 +365,18 @@ defmodule NervesHubLink.Socket do
   end
 
   @impl Slipstream
+  def handle_info(:connect_check_network_availability, socket) do
+    case :inet.gethostbyname(to_charlist(socket.assigns.config.device_api_host)) do
+      {:ok, _} ->
+        {:noreply, socket, {:continue, :connect}}
+
+      _ ->
+        Logger.info("[NervesHubLink] waiting for network to become available")
+        schedule_network_availability_check(2_000)
+        {:noreply, socket}
+    end
+  end
+
   def handle_info({:tty_data, data}, socket) do
     _ = push(socket, @console_topic, "up", %{data: data})
     {:noreply, set_iex_timer(socket)}
@@ -432,6 +460,10 @@ defmodule NervesHubLink.Socket do
   @impl Slipstream
   def terminate(_reason, socket) do
     disconnect(socket)
+  end
+
+  defp schedule_network_availability_check(delay \\ 100) do
+    Process.send_after(self(), :connect_check_network_availability, delay)
   end
 
   defp handle_join_reply(%{"firmware_url" => url} = update) when is_binary(url) do


### PR DESCRIPTION
This is a different approach to https://github.com/nerves-hub/nerves_hub_link/pull/177

This PR adjusts the `NervesHubLink.Socket` to check for network availability before starting the connection process.

This only happens after the `Socket` is initialized and doesn't affect the standard disconnection and reconnection logic (`handle_disconnect` and `reconnect`)

This bahaviour can be disabled by adding :

```elixir
config :nerves_hub_link, connect_wait_for_network: false
```

to your projects config.