### PR TITLE
Fix no match error when uploading files

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -356,7 +356,7 @@ defmodule NervesHubLink.Socket do
   def handle_message(@console_topic, "file-data", params, socket) do
     path = Path.join(socket.assigns.data_path, params["filename"])
 
-    {:ok, _res} =
+    _res =
       File.open!(path, [:append], fn fd ->
         chunk = Base.decode64!(params["data"])
         IO.binwrite(fd, chunk)

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubLink.UpdateManagerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   alias NervesHubLink.{FwupConfig, UpdateManager}
   alias NervesHubLink.Message.{FirmwareMetadata, UpdateInfo}
   alias NervesHubLink.Support.FWUPStreamPlug


### PR DESCRIPTION
The final IO.binwrite call returns `:ok`. This caused the following
match error:

```
MatchError: no match of right hand side value: :ok
  File "lib/nerves_hub_link/socket.ex", line 338, in NervesHubLink.Socket.handle_message/4
  File "lib/slipstream/callback.ex", line 34, in anonymous fn/3 in Slipstream.Callback.dispatch/3
  File "lib/slipstream/telemetry_helper.ex", line 175, in anonymous fn/2 in Slipstream.TelemetryHelper.wrap_dispatch/4
  File "telemetry.erl", line 321, in :telemetry.span/3
  File "gen_server.erl", line 1095, in :gen_server.try_handle_info/3
  File "gen_server.erl", line 1183, in :gen_server.handle_msg/6
  File "proc_lib.erl", line 241, in :proc_lib.init_p_do_apply/3
```
