### PR TITLE
request a port as needed

### DIFF
--- a/test/nerves_hub_link/downloader_test.exs
+++ b/test/nerves_hub_link/downloader_test.exs
@@ -6,6 +6,7 @@ defmodule NervesHubLink.DownloaderTest do
     IdleTimeoutPlug,
     RangeRequestPlug,
     RedirectPlug,
+    Utils,
     XRetryNumberPlug
   }
 
@@ -55,7 +56,7 @@ defmodule NervesHubLink.DownloaderTest do
 
   describe "idle timeout" do
     setup do
-      port = 7010
+      port = Utils.unique_port_number()
 
       {:ok, plug} =
         start_supervised(
@@ -83,7 +84,7 @@ defmodule NervesHubLink.DownloaderTest do
 
   describe "http error" do
     setup do
-      port = 7020
+      port = Utils.unique_port_number()
 
       {:ok, plug} =
         start_supervised({Plug.Cowboy, scheme: :http, plug: HTTPErrorPlug, options: [port: port]})
@@ -103,7 +104,7 @@ defmodule NervesHubLink.DownloaderTest do
 
   describe "range" do
     setup do
-      port = 7030
+      port = Utils.unique_port_number()
 
       {:ok, plug} =
         start_supervised(
@@ -128,7 +129,7 @@ defmodule NervesHubLink.DownloaderTest do
 
   describe "redirect" do
     setup do
-      port = 7040
+      port = Utils.unique_port_number()
 
       {:ok, plug} =
         start_supervised(
@@ -149,7 +150,7 @@ defmodule NervesHubLink.DownloaderTest do
 
   describe "xretry" do
     setup do
-      port = 7050
+      port = Utils.unique_port_number()
 
       {:ok, plug} =
         start_supervised(

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -2,11 +2,11 @@ defmodule NervesHubLink.UpdateManagerTest do
   use ExUnit.Case
   alias NervesHubLink.{FwupConfig, UpdateManager}
   alias NervesHubLink.Message.{FirmwareMetadata, UpdateInfo}
-  alias NervesHubLink.Support.FWUPStreamPlug
+  alias NervesHubLink.Support.{FWUPStreamPlug, Utils}
 
   describe "fwup stream" do
     setup do
-      port = 6000
+      port = Utils.unique_port_number()
       devpath = "/tmp/fwup_output"
 
       update_payload = %UpdateInfo{

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,0 +1,5 @@
+defmodule NervesHubLink.Support.Utils do
+  def unique_port_number() do
+    System.unique_integer([:positive, :monotonic]) + 6000
+  end
+end


### PR DESCRIPTION
its likely overkill, but it does mean we don't need to remember which port number is being defined in which test