### PR TITLE
Remove the `[] =` for fwup_public_keys

### DIFF
--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -213,7 +213,7 @@ defmodule NervesHubLink.UpdateManager do
   end
 
   @spec start_fwup_stream(UpdateInfo.t(), [binary()], State.t()) :: State.t()
-  defp start_fwup_stream(%UpdateInfo{} = update_info, [] = fwup_public_keys, state) do
+  defp start_fwup_stream(%UpdateInfo{} = update_info, fwup_public_keys, state) do
     pid = self()
     fun = &send(pid, {:download, &1})
     {:ok, download} = Downloader.start_download(update_info.firmware_url, fun)
@@ -236,7 +236,7 @@ defmodule NervesHubLink.UpdateManager do
   end
 
   @spec fwup_args(FwupConfig.t(), list(String.t())) :: [String.t()]
-  defp fwup_args(%FwupConfig{} = config, [] = fwup_public_keys) do
+  defp fwup_args(%FwupConfig{} = config, fwup_public_keys) do
     args = ["--apply", "--no-unmount", "-d", config.fwup_devpath, "--task", config.fwup_task]
 
     Enum.reduce(fwup_public_keys, args, fn public_key, args ->


### PR DESCRIPTION
This caused a pattern match error when public key(s) were present because this was matching against an empty list.