### PR TITLE
Run a NervesHub script on device

### DIFF
--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -3,7 +3,7 @@ defmodule NervesHubLink.Configurator do
   alias __MODULE__.Config
   require Logger
 
-  @device_api_version "2.0.0"
+  @device_api_version "2.1.0"
   @console_version "2.0.0"
 
   defmodule Config do

--- a/lib/nerves_hub_link/script.ex
+++ b/lib/nerves_hub_link/script.ex
@@ -1,0 +1,32 @@
+defmodule NervesHubLink.Script do
+  # Inspired from ExUnit.CaptureIO
+  # https://github.com/elixir-lang/elixir/blob/main/lib/ex_unit/lib/ex_unit/capture_io.ex
+
+  @doc """
+  Run a script from NervesHub and capture its output
+  """
+  def capture(text) do
+    original_gl = Process.group_leader()
+    {:ok, string_io} = StringIO.open("")
+
+    try do
+      Process.group_leader(self(), string_io)
+
+      try do
+        Code.eval_string(text)
+      catch
+        kind, reason ->
+          {:ok, {_input, output}} = StringIO.close(string_io)
+          result = Exception.format_banner(kind, reason, __STACKTRACE__)
+          output = output <> "\n" <> result
+          {nil, output}
+      else
+        result ->
+          {:ok, {_input, output}} = StringIO.close(string_io)
+          {result, output}
+      end
+    after
+      Process.group_leader(self(), original_gl)
+    end
+  end
+end

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -9,6 +9,7 @@ defmodule NervesHubLink.Socket do
   alias NervesHubLink.Client
   alias NervesHubLink.Configurator
   alias NervesHubLink.Configurator.SharedSecret
+  alias NervesHubLink.Script
   alias NervesHubLink.UpdateManager
   alias NervesHubLink.UploadFile
 
@@ -296,6 +297,19 @@ defmodule NervesHubLink.Socket do
 
   def handle_message(@device_topic, "identify", _params, socket) do
     Client.identify()
+    {:ok, socket}
+  end
+
+  def handle_message(@device_topic, "scripts/run", params, socket) do
+    {return, output} = Script.capture(params["text"])
+
+    _ =
+      push(socket, @device_topic, "scripts/run", %{
+        ref: params["ref"],
+        output: output,
+        return: inspect(return, pretty: true)
+      })
+
     {:ok, socket}
   end
 

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -301,15 +301,8 @@ defmodule NervesHubLink.Socket do
   end
 
   def handle_message(@device_topic, "scripts/run", params, socket) do
-    {return, output} = Script.capture(params["text"])
-
-    _ =
-      push(socket, @device_topic, "scripts/run", %{
-        ref: params["ref"],
-        output: output,
-        return: inspect(return, pretty: true)
-      })
-
+    # See related handle_info for pushing back the script result
+    :ok = Script.capture(params["text"], params["ref"])
     {:ok, socket}
   end
 
@@ -413,6 +406,17 @@ defmodule NervesHubLink.Socket do
         schedule_network_availability_check(2_000)
         {:noreply, socket}
     end
+  end
+
+  def handle_info({"scripts/run", ref, output, return}, socket) do
+    _ =
+      push(socket, @device_topic, "scripts/run", %{
+        ref: ref,
+        output: output,
+        return: inspect(return, pretty: true)
+      })
+
+    {:noreply, socket}
   end
 
   def handle_info({:tty_data, data}, socket) do


### PR DESCRIPTION
Evaluate a script locally on device from NervesHub instead of relying on the console channel. Bumps the api version so NervesHub is aware this is possible on the connecting device.