### PR TITLE
Simplify connection settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,15 @@ version: 2.1
 latest: &latest
   pattern: "^1.16.*$"
 
-tags: &tags
-  [
+tags:
+  &tags [
+    1.17.2-erlang-27.0-alpine-3.20.1,
     1.16.2-erlang-26.2.4-alpine-3.19.1,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.2-erlang-25.2-alpine-3.16.3,
     1.13.4-erlang-24.3.4.10-alpine-3.17.2,
     1.12.3-erlang-24.3.4.10-alpine-3.17.2,
-    1.11.4-erlang-23.3.4.18-alpine-3.16.2
+    1.11.4-erlang-23.3.4.18-alpine-3.16.2,
   ]
 
 jobs:
@@ -59,7 +60,7 @@ jobs:
 
   automerge:
     docker:
-        - image: alpine:3.18.4
+      - image: alpine:3.18.4
     steps:
       - run:
           name: Install GitHub CLI

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ nerves_hub-*.tar
 
 /.nerves-hub
 /nerves-hub
+
+/tmp

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ config :nerves_hub_link, ssl: [cacerts: my_der_list]
 
 ### Verifying network availability
 
-`NervesHubLink` will attempt to verify that the network is available before initiating the first connection attempt. This is done by checking if the `NervesHub` host address (`config.device_api_host`) can be resolved. If the network isn't available then the check will be run again in 2 seconds.
+`NervesHubLink` will attempt to verify that the network is available before initiating the first connection attempt. This is done by checking if the `NervesHub` host address (`config.host`) can be resolved. If the network isn't available then the check will be run again in 2 seconds.
 
 You can disable this behaviour with the following config:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A full example config:
 
 ```elixir
 config :nerves_hub_link,
-  device_api_host: "your.nerveshub.host",
+  host: "your.nerveshub.host",
   shared_secret: [
     product_key: "<product_key>",
     product_secret: "<product_secret>",
@@ -86,7 +86,7 @@ This allows your config to be simplified to:
 
 ```elixir
 config :nerves_hub_link,
-  device_api_host: "your.nerveshub.host"
+  host: "your.nerveshub.host"
 ```
 
 NervesKey will default to using I2C bus 1 and the `:primary` certificate pair (`:primary` is one-time configurable and `:aux` may be updated). You can customize these options to use a different bus and certificate pair:
@@ -103,7 +103,7 @@ If you would like to use certificate device authentication, but you are not usin
 
 ```elixir
 config :nerves_hub_link,
-  device_api_host: "your.nerveshub.host",
+  host: "your.nerveshub.host",
   configurator: NervesHubLink.Configurator.LocalCertKey
 ```
 
@@ -111,7 +111,7 @@ By default the configurator will use a certificate found at `/data/nerves_hub/ce
 
 ```elixir
 config :nerves_hub_link,
-  device_api_host: "your.nerveshub.host",
+  host: "your.nerveshub.host",
   configurator: NervesHubLink.Configurator.LocalCertKey,
   ssl: [
     certfile: "/path/to/certfile.pem",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,8 +2,7 @@ import Config
 
 # Device HTTP connection.
 config :nerves_hub_link,
-  device_api_host: "0.0.0.0",
-  device_api_port: 4001
+  host: "0.0.0.0:4001"
 
 # nerves_runtime needs to disable
 # and mock out some parts.

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,8 +5,7 @@ config :nerves_hub_link,
   archive_public_keys: ["a key?"],
   connect: false,
   client: NervesHubLink.ClientMock,
-  device_api_host: "0.0.0.0",
-  device_api_port: 4001,
+  host: "0.0.0.0:4001",
   fwup_public_keys: ["a key"],
   # SSL values are used in a test.
   ssl: [

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -105,8 +105,7 @@ defmodule NervesHubLink.Configurator do
     base = struct(Config, Application.get_all_env(:nerves_hub_link))
 
     host = if String.contains?(base.host, "://"), do: base.host, else: "wss://#{base.host}"
-    url = URI.parse(host) |> URI.append_path("/socket/websocket")
-
+    url = URI.parse(host) |> URI.merge("/socket/websocket")
     socket = Keyword.put_new(base.socket, :url, url)
 
     ssl =

--- a/lib/nerves_hub_link/configurators/local_cert_key.ex
+++ b/lib/nerves_hub_link/configurators/local_cert_key.ex
@@ -55,7 +55,7 @@ defmodule NervesHubLink.Configurator.LocalCertKey do
     %{config | ssl: ssl}
   end
 
-  defp maybe_add_sni(%{ssl: ssl, device_api_sni: sni} = config) do
+  defp maybe_add_sni(%{ssl: ssl, sni: sni} = config) do
     ssl = Keyword.put_new(ssl, :server_name_indication, to_charlist(sni))
     %{config | ssl: ssl}
   end

--- a/lib/nerves_hub_link/configurators/nerves_key.ex
+++ b/lib/nerves_hub_link/configurators/nerves_key.ex
@@ -59,7 +59,7 @@ if Code.ensure_loaded?(NervesKey) do
       end)
     end
 
-    defp maybe_add_sni(ssl, %{device_api_sni: sni}) do
+    defp maybe_add_sni(ssl, %{sni: sni}) do
       Keyword.put_new(ssl, :server_name_indication, to_charlist(sni))
     end
   end

--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -12,7 +12,7 @@ defmodule NervesHubLink.Configurator.SharedSecret do
       |> Keyword.put_new(:cacerts, Certificate.ca_certs())
 
     # Shared Secret Auth uses a different socket path
-    url = URI.merge(socket[:url], "/device-socket/websocket") |> to_string()
+    url = URI.merge(socket[:url], "/device-socket/websocket")
 
     %{config | ssl: ssl, socket: Keyword.merge(socket, headers: headers(config), url: url)}
   end

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -100,7 +100,7 @@ defmodule NervesHubLink.Socket do
 
   @impl Slipstream
   def handle_continue(:connect, %{assigns: %{config: config}} = socket) do
-    Logger.info("[NervesHubLink] connecting to #{config.device_api_host}")
+    Logger.info("[NervesHubLink] connecting to #{config.socket[:url].host}")
 
     rejoin_after = Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
 
@@ -129,7 +129,7 @@ defmodule NervesHubLink.Socket do
 
   @impl Slipstream
   def handle_connect(%{assigns: %{config: config}} = socket) do
-    Logger.info("[NervesHubLink] connection to #{config.device_api_host} succeeded")
+    Logger.info("[NervesHubLink] connection to #{config.socket[:url].host} succeeded")
 
     currently_downloading_uuid = UpdateManager.currently_downloading_uuid()
 

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -104,11 +104,12 @@ defmodule NervesHubLink.Socket do
 
     rejoin_after = Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
 
-    mint_opts = if config.socket[:url].scheme == "wss" do
-      [protocols: [:http1], transport_opts: config.ssl]
-    else
-      [protocols: [:http1]]
-    end
+    mint_opts =
+      if config.socket[:url].scheme == "wss" do
+        [protocols: [:http1], transport_opts: config.ssl]
+      else
+        [protocols: [:http1]]
+      end
 
     opts = [
       mint_opts: mint_opts,
@@ -397,6 +398,7 @@ defmodule NervesHubLink.Socket do
   @impl Slipstream
   def handle_info(:connect_check_network_availability, socket) do
     hostname = URI.parse(socket.assigns.config.socket[:url]).host
+
     case :inet.gethostbyname(to_charlist(hostname)) do
       {:ok, _} ->
         {:noreply, socket, {:continue, :connect}}

--- a/mix.exs
+++ b/mix.exs
@@ -32,9 +32,7 @@ defmodule NervesHubLink.MixProject do
   def application do
     [
       env: [
-        device_api_host: nil,
-        device_api_port: 443,
-        device_api_sni: nil,
+        host: nil,
         fwup_public_keys: []
       ],
       extra_applications: [:logger, :iex, :inets, :sasl],


### PR DESCRIPTION
- instead of passing in `device_api_host` and `device_api_port`, you can now do all this via `host`
  - you can pass in just a host, or host and port, and it will default to `wss`
- this also fixes an issue where `ws` wasn't supported (I can now use this on localhost easily)
- I've also changed `device_api_sni` to just `sni`
- this is a breaking change