### PR TITLE
Extension mechanism

### DIFF
--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -27,10 +27,12 @@ defmodule NervesHubLink.Application do
   defp children(%{connect: false}, _fwup_config), do: []
 
   defp children(config, fwup_config) do
-    [
-      {UpdateManager, fwup_config},
-      {ArchiveManager, config},
-      {Socket, config}
-    ]
+    # Start extensions first or they might miss Socket messages
+    config.extensions ++
+      [
+        {UpdateManager, fwup_config},
+        {ArchiveManager, config},
+        {Socket, config}
+      ]
   end
 end

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -28,7 +28,8 @@ defmodule NervesHubLink.Configurator do
               shared_secret: [],
               sni: nil,
               socket: [],
-              ssl: []
+              ssl: [],
+              extensions: []
 
     @type t() :: %__MODULE__{
             archive_public_keys: [binary()],
@@ -52,7 +53,8 @@ defmodule NervesHubLink.Configurator do
             shared_secret: [product_key: String.t(), product_secret: String.t()],
             sni: String.t(),
             socket: any(),
-            ssl: [:ssl.tls_client_option()]
+            ssl: [:ssl.tls_client_option()],
+            extensions: [NervesHub.Extension.t()]
           }
   end
 

--- a/lib/nerves_hub_link/extension.ex
+++ b/lib/nerves_hub_link/extension.ex
@@ -1,6 +1,21 @@
 defmodule NervesHubLink.Extension do
   @moduledoc """
-  An Extension is a
+  An Extension is a GenServer that can handle messages passed down from NervesHub
+  and that can send messages up to NervesHub. It utilizes the regular NervesHubLink
+  connection but are isolated to avoid crashing the main connection for things that
+  are less important than the firmware update functionality.
+
+  To configure an extension, simply add a child as if for a Supervisor, in config:alarm_handler
+
+  ```
+  config :nerves_hub_link,
+    extensions: [
+      NervesHubLink.Geo,
+      NervesHubLink.Health,
+      {MyExtension, interval: 500}
+    ]
+  ```
+
   """
   @callback events() :: [String.t()]
 

--- a/lib/nerves_hub_link/extension.ex
+++ b/lib/nerves_hub_link/extension.ex
@@ -1,0 +1,69 @@
+defmodule NervesHubLink.Extension do
+  @moduledoc """
+  An Extension is a
+  """
+  @callback events() :: [String.t()]
+
+  @callback handle_message(event :: String.t(), params :: map(), state :: term()) ::
+              {:noreply, new_state :: term()}
+              | {:noreply, new_state :: term(),
+                 timeout() | :hibernate | {:continue, continue_arg :: term()}}
+              | {:stop, reason :: term(), new_state :: term()}
+
+  @type t :: atom() | {atom(), term()} | Supervisor.child_spec()
+
+  def forward(extension_events, event, params) do
+    extension = Map.get(extension_events, event)
+
+    if is_atom(extension) do
+      pid = Process.whereis(extension)
+
+      if pid do
+        send(pid, {:event, event, params})
+      end
+    end
+  end
+
+  def extension_events_from_config(extensions) do
+    extensions
+    |> Enum.flat_map(fn child_spec ->
+      # Unpack child structure
+      module =
+        case child_spec do
+          module when is_atom(module) ->
+            module
+
+          child when is_tuple(child) ->
+            elem(child, 0)
+
+          %{start: {module, _, _}} ->
+            module
+        end
+
+      module.events()
+      |> Enum.map(fn event ->
+        {event, module}
+      end)
+    end)
+    |> Map.new()
+  end
+
+  defmacro __using__(_opts) do
+    quote do
+      use GenServer
+      @behaviour NervesHubLink.Extension
+
+      def start_link(opts) do
+        GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+      end
+
+      def handle_info({:event, event, params}, state) do
+        handle_message(event, params, state)
+      end
+
+      def push(event, params) do
+        send(NervesHubLink.Socket, {:extension_msg, event, params})
+      end
+    end
+  end
+end

--- a/test/nerves_hub_link/extension_test.exs
+++ b/test/nerves_hub_link/extension_test.exs
@@ -1,0 +1,34 @@
+defmodule NervesHubLink.ExtensionTest do
+  use ExUnit.Case
+
+  alias NervesHubLink.Extension
+
+  defmodule MyExtension do
+    use NervesHubLink.Extension
+
+    @impl true
+    def init(_opts) do
+      {:ok, %{}}
+    end
+
+    @impl NervesHubLink.Extension
+    def events do
+      ["my-event"]
+    end
+
+    @impl NervesHubLink.Extension
+    def handle_message("my-event", %{sender: pid}, state) do
+      send(pid, :got_message)
+      push("my-push", %{data: 1})
+      {:noreply, state}
+    end
+  end
+
+  test "try extension receive and send" do
+    {:ok, _pid} = MyExtension.start_link([])
+    extensions = [MyExtension]
+    events = Extension.extension_events_from_config(extensions)
+    Extension.forward(events, "my-event", %{sender: self()})
+    assert_receive :got_message
+  end
+end


### PR DESCRIPTION
The goal is to create a mechanism allowing us to re-use the existing connection
and add new functionality based on messages received and passing messages back
up the WebSocket.
    
The important part is that new features and functionality that are not core should
be possible to deliver as libraries and plugged in via configuration. They should
not be able to crash the Socket and prevent firmware updates from succeeding.

This is not complete isolation. Things could still be brought down by a really broken
extension that brings down the :nerves_hub_link app but extensions run quite well
separated.

This should let us update NervesHubLink without churning on sensitive code that could affect a lot of devices negatively.