### PR TITLE
Fix problem where signed_at time was often expired

### DIFF
--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -29,7 +29,9 @@ defmodule NervesHubLink.Configurator.SharedSecret do
       |> Keyword.put_new(:key_length, 32)
       |> Keyword.put_new(:signature_version, "NH1")
       |> Keyword.put_new(:identifier, Nerves.Runtime.serial_number())
-      |> Keyword.put(:signed_at, System.system_time(:second))
+      # Important to use os_time as system_time is not updated by NervesTime
+      # nearly as quickly
+      |> Keyword.put(:signed_at, System.os_time(:second))
 
     alg =
       "#{opts[:signature_version]}-HMAC-#{opts[:key_digest]}-#{opts[:key_iterations]}-#{opts[:key_length]}"

--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -29,8 +29,8 @@ defmodule NervesHubLink.Configurator.SharedSecret do
       |> Keyword.put_new(:key_length, 32)
       |> Keyword.put_new(:signature_version, "NH1")
       |> Keyword.put_new(:identifier, Nerves.Runtime.serial_number())
-      # Important to use os_time as system_time is not updated by NervesTime
-      # nearly as quickly
+      # Important to use os_time as system_time is not updated by Erlang as
+      # quickly. See https://www.erlang.org/doc/apps/erts/time_correction#erlang-system-time
       |> Keyword.put(:signed_at, System.os_time(:second))
 
     alg =


### PR DESCRIPTION
When rebooting a device NervesTime will try to restore a reasonable time from the RTC or the FileTime simulated RTC. This then sets OS time.

The shared secret signing code was pulling System.system_time/1 which can lag behind System.os_time/1 for many minutes and can often start on a time that is wildly out of whack.

This changes to use os_time meaning devices should reboot and connect much faster by default.