### PR TITLE
Rescue errors in alarms report

### DIFF
--- a/lib/nerves_hub_link/extensions/health/default_report.ex
+++ b/lib/nerves_hub_link/extensions/health/default_report.ex
@@ -30,6 +30,9 @@ defmodule NervesHubLink.Extensions.Health.DefaultReport do
           {"bad alarm term", ""}
       end
     end
+  rescue
+    error ->
+      %{NervesHubLink.AlarmReportFailed => inspect(error)}
   end
 
   @impl Report

--- a/lib/nerves_hub_link/extensions/health/default_report.ex
+++ b/lib/nerves_hub_link/extensions/health/default_report.ex
@@ -22,17 +22,13 @@ defmodule NervesHubLink.Extensions.Health.DefaultReport do
 
   @impl Report
   def alarms do
-    for {id, description} <- :alarm_handler.get_alarms(), into: %{} do
-      try do
-        {inspect(id), inspect(description)}
-      catch
-        _, _ ->
-          {"bad alarm term", ""}
-      end
+    case :alarm_handler.get_alarms() do
+      alarms when is_list(alarms) ->
+        for {id, description} <- alarms, into: %{}, do: {inspect(id), inspect(description)}
+
+      err ->
+        %{"NervesHubLink.AlarmReportFailed" => inspect(err)}
     end
-  rescue
-    error ->
-      %{NervesHubLink.AlarmReportFailed => inspect(error)}
   end
 
   @impl Report


### PR DESCRIPTION
Fix for issue #250 

This will rescue any exception when creating alarm report for health checks.

It won't solve the problem where `:alarm_handler.get_alarms` returns `{:error, :bad_module}` though.
Any input on that is very welcomed.
