### PR TITLE
Add support for tracking total network traffic

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -19,6 +19,9 @@ The default set of metrics used by the `Health.DefaultReport` are:
 - `NervesHubLink.Extensions.Health.MetricSet.Memory` - Memory size (MB), used (MB), and percentage used.
 - `NervesHubLink.Extensions.Health.MetricSet.Disk` - Disk size (KB), available (KB), and percentage used.
 
+And one optional metric set:
+- `NervesHubLink.Extensions.Health.MetricSet.NetworkTraffic` - Total bytes sent and received (per interface).
+
 You can also create your own metric sets by implementing the `NervesHubLink.Extensions.Health.MetricSet`
 behaviour.
 

--- a/lib/nerves_hub_link/extensions/health/metric_set/network_traffic.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/network_traffic.ex
@@ -1,0 +1,53 @@
+defmodule NervesHubLink.Extensions.Health.MetricSet.NetworkTraffic do
+  @moduledoc """
+  Health report metrics for bytes sent and received (total) per interface.
+
+  The keys used in the report are:
+    - [interface]_bytes_received_total: Total bytes received by the interface
+    - [interface]_bytes_sent_total: Total bytes sent by the interface
+  """
+  @behaviour NervesHubLink.Extensions.Health.MetricSet
+
+  require Logger
+
+  @impl NervesHubLink.Extensions.Health.MetricSet
+  def sample() do
+    if File.exists?("/proc/net/dev") do
+      {output, _} = System.cmd("cat", ["/proc/net/dev"])
+      parse_proc_net_dev(output)
+    else
+      Logger.warning("[Health.MetricSet.NetworkTraffic] Network traffic metrics not available")
+      %{}
+    end
+  rescue
+    _ ->
+      %{}
+  end
+
+  defp parse_proc_net_dev(output) do
+    [_top, _header | data] = String.split(output, "\n")
+
+    {_, data} = List.pop_at(data, -1)
+
+    data
+    |> Enum.map(fn line ->
+      [interface, bytes_received, _, _, _, _, _, _, _, bytes_sent | _] = String.split(line)
+
+      %{
+        interface: String.replace(interface, ":", ""),
+        bytes_received_total: bytes_received,
+        bytes_sent_total: bytes_sent
+      }
+    end)
+    |> Enum.reject(fn %{interface: interface} ->
+      interface == "lo"
+    end)
+    |> Enum.map(fn data ->
+      %{
+        "#{data.interface}_bytes_received_total" => data.bytes_received_total,
+        "#{data.interface}_bytes_sent_total" => data.bytes_sent_total
+      }
+    end)
+    |> Enum.reduce(%{}, &Map.merge/2)
+  end
+end


### PR DESCRIPTION
This sends the total bytes sent and received for each interface, except local.

One thing we should think about is how to track the delta. 

A potential issue I anticipate is a connection crashing, making it look like the device has consumed a lot of data from its first report.

I wonder if we should track the previous total in link and only send the delta. If there is no previous total, we send zeros.

But the downside of this is that if a report isn't received and processed, we will miss some data. Sooooo maybe, we send totals, but we cache the first report and use that for the baseline for future reports.