### PR TITLE
Support a new set of firmware update status messages

### DIFF
--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -75,14 +75,14 @@ defmodule NervesHubLink do
   @doc """
   Send update progress percentage for display in web
   """
-  @spec send_update_progress(non_neg_integer()) :: :ok
-  defdelegate send_update_progress(progress), to: Socket
+  @spec send_firmware_update_progress(non_neg_integer()) :: :ok
+  defdelegate send_firmware_update_progress(progress), to: Socket
 
   @doc """
-  Send an update status to web
+  Send a firmware status update status to hub
   """
-  @spec send_update_status(String.t() | atom()) :: :ok
-  defdelegate send_update_status(status), to: Socket
+  @spec send_firmware_update_status(status :: atom(), payload :: map()) :: :ok
+  defdelegate send_firmware_update_status(status, payload \\ %{}), to: Socket
 
   @doc """
   Send a file to the connected console

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -202,12 +202,13 @@ defmodule NervesHubLink.Client do
     # TODO: nasty side effects here. Consider moving somewhere else
     case data do
       {:progress, percent} ->
-        NervesHubLink.send_update_progress(percent)
+        NervesHubLink.send_firmware_update_progress(percent)
 
       {:error, _, message} ->
-        NervesHubLink.send_update_status("fwup error #{message}")
+        NervesHubLink.send_firmware_update_status(:error, %{reason: message})
 
       {:ok, 0, _message} ->
+        NervesHubLink.send_firmware_update_status(:finalizing)
         initiate_reboot()
 
       _ ->

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -169,6 +169,8 @@ defmodule NervesHubLink.Configurator do
       |> Map.put("fwup_version", fwup_version())
       |> Map.put("device_api_version", @device_api_version)
       |> Map.put("console_version", @console_version)
+      |> Map.put("library", "nerves_hub_link")
+      |> Map.put("library_version", to_string(Application.spec(:nerves_hub_link, :vsn)))
 
     %{base | params: params, socket: socket, ssl: ssl, fwup_devpath: fwup_devpath}
   end

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -169,8 +169,8 @@ defmodule NervesHubLink.Configurator do
       |> Map.put("fwup_version", fwup_version())
       |> Map.put("device_api_version", @device_api_version)
       |> Map.put("console_version", @console_version)
-      |> Map.put("library", "nerves_hub_link")
-      |> Map.put("library_version", to_string(Application.spec(:nerves_hub_link, :vsn)))
+      |> Map.put("client", "nerves_hub_link")
+      |> Map.put("client_version", to_string(Application.spec(:nerves_hub_link, :vsn)))
 
     %{base | params: params, socket: socket, ssl: ssl, fwup_devpath: fwup_devpath}
   end

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -27,7 +27,7 @@ defmodule NervesHubLink.Configurator do
 
   require Logger
 
-  @device_api_version "2.2.0"
+  @device_api_version "2.3.0"
   @console_version "2.0.0"
 
   defmodule Config do

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -301,7 +301,7 @@ defmodule NervesHubLink.Socket do
         socket,
         @device_topic,
         "firmware_update_status",
-        Map.merge(payload, %{status: "applying"})
+        Map.merge(payload, %{status: "finalizing"})
       )
 
     _ = await_reply(push_ref)

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -27,7 +27,7 @@ defmodule NervesHubLink.UpdateManager do
   @type status ::
           :idle
           | {:updating, integer()}
-          | :applying
+          | :finalizing
 
   @type previous_status ::
           :ignored
@@ -166,7 +166,7 @@ defmodule NervesHubLink.UpdateManager do
            state
            | fwup: nil,
              update_info: nil,
-             status: :applying,
+             status: :finalizing,
              previous_status: :successful
          }}
 

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -29,19 +29,22 @@ defmodule NervesHubLink.UpdateManager do
           | {:updating, integer()}
           | :finalizing
 
-  @type t :: %__MODULE__{
-          status: status(),
-          download: nil | GenServer.server(),
-          fwup: nil | GenServer.server(),
-          fwup_config: FwupConfig.t(),
-          update_info: nil | UpdateInfo.t()
-        }
+  defmodule State do
+    @moduledoc false
+    @type t :: %__MODULE__{
+            status: UpdateManager.status(),
+            download: nil | GenServer.server(),
+            fwup: nil | GenServer.server(),
+            fwup_config: FwupConfig.t(),
+            update_info: nil | UpdateInfo.t()
+          }
 
-  defstruct status: :idle,
-            fwup: nil,
-            download: nil,
-            fwup_config: nil,
-            update_info: nil
+    defstruct status: :idle,
+              fwup: nil,
+              download: nil,
+              fwup_config: nil,
+              update_info: nil
+  end
 
   @doc """
   Must be called when an update payload is dispatched from
@@ -164,7 +167,7 @@ defmodule NervesHubLink.UpdateManager do
       {:progress, percent} ->
         {:noreply, %State{state | status: {:updating, percent}}}
 
-      {:error, _, message} ->
+      {:error, _, _message} ->
         Alarms.clear_alarm(NervesHubLink.UpdateInProgress)
         {:noreply, %State{state | status: :idle}}
 

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -224,7 +224,7 @@ defmodule NervesHubLink.UpdateManager do
       {:reschedule, ms} ->
         until =
           DateTime.utc_now()
-          |> DateTime.add(round(ms / 1_000), :second)
+          |> DateTime.add(ms, :millisecond)
 
         NervesHubLink.send_firmware_update_status(:reschedule, %{until: until})
         Logger.info("[NervesHubLink] rescheduling firmware update in #{ms / 1_000} seconds")

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -62,13 +62,8 @@ defmodule NervesHubLink.UpdateManagerTest do
       }
 
       {:ok, manager} = UpdateManager.start_link(fwup_config)
-      assert UpdateManager.apply_update(manager, update_payload, []) == :update_rescheduled
+      assert UpdateManager.apply_update(manager, update_payload, []) == :rescheduled
       assert_received :rescheduled
-      refute_received {:fwup, _}
-
-      assert_receive {:fwup, {:progress, 0}}, 250
-      assert_receive {:fwup, {:progress, 100}}
-      assert_receive {:fwup, {:ok, 0, ""}}
     end
 
     test "apply with fwup environment", %{update_payload: update_payload, devpath: devpath} do


### PR DESCRIPTION
These new accepted Hub messages hook deeper into the updating lifecycle, as well as fixing issues where new firmware aren't sent to devices when an update is ignored or encounters errors.

This also moves the responsibility for rescheduling the update to Hub, which will resend the update shortly after the date sent by Link.

**The new states sent to hub are:**
- `:updating` (the progress is sent with this message)
- `:finalizing` (the download and applying of the update has finished and the device is about to reboot)
- `:ignored` (the device doesn't want the update. We could also allow a 'reason' to be sent)
- `:reschedule` (including the datetime to block device updates until)
- `:error` (something went wrong, a reason is also sent)

**Two things to discuss/consider:**
- I've changed the `finalizing` push to send a reply from hub, which allows us to make sure hub knows we are about to reboot, and thus track if a device updated by never came back online. I think, for consistency, we make all pushes to `firmware_update_status` return replies of `:ok`, and then its up to Link to decide if it cares about them or not.
- FWUP can send out info and warning messages (eg. https://github.com/nerves-project/nerves_system_rpi0/blob/main/fwup.conf#L292), but they are captured as 'warnings'. We could also send these up to Hub for extra data on how the update is going.

**Some bits to track**
- [ ] Update Hub to accept these messages (I have a changeset ready but we first need to merge in the new orchestrator)
- [ ] Test with some devices