### PR TITLE
Health enhancements

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -11,20 +11,63 @@ Your NervesHub server controls enabling and disabling extensions to allow you to
 
 ## Health
 
-You can add your own metrics, metadata and alarms:
+You can add your own metrics, metadata and alarms.
 
-In your config.exs for the device:
+The default set of metrics used by the `Health.DefaultReport` are:
+
+- `NervesHubLink.Extensions.Health.MetricSet.CPU` - CPU temperature, usage (percentage), and load averages.
+- `NervesHubLink.Extensions.Health.MetricSet.Memory` - Memory size (MB), used (MB), and percentage used.
+- `NervesHubLink.Extensions.Health.MetricSet.Disk` - Disk size (KB), available (KB), and percentage used.
+
+You can also create your own metric sets by implementing the `NervesHubLink.Extensions.Health.MetricSet`
+behaviour.
+
+If a library you are using provides a metric set, you can add it to the list of metrics, but please ensure
+to include all the metric sets you want to use. If you want to include the full default set, you can use
+`:default` or `:defaults` in your metric set list.
+
+eg.
 
 ```
 config :nerves_hub_link,
   health: [
-    # metrics are added with a key and MFA
-    # the function should return a number (int or float is fine)
-    metrics: %{
-      "cats_passed" => {CatCounter, :total, []}
-    },
+    metric_sets: [
+      :defaults,
+      MyApp.HealthMetrics,
+      ALibrary.BatteryMetrics
+    ]
+  ]
+```
 
-    # metadata is identical but should return a string
+If you only want to use some of the default metrics, you can specify them explicitly:
+
+```
+config :nerves_hub_link,
+  health: [
+    metric_sets: [
+      NervesHubLink.Extensions.Health.MetricSet.CPU,
+      NervesHubLink.Extensions.Health.MetricSet.Memory
+      # the disk metrics have been excluded
+    ]
+  ]
+```
+
+And if you don't want to use any metric sets, you can set the `metric_sets` option to an empty list.
+
+```
+config :nerves_hub_link,
+  health: [
+    metric_sets: []
+  ]
+```
+
+If you want to add custom metadata to the default health report, you can specify it with:
+
+```
+config :nerves_hub_link,
+  health: [
+    # metadata is added with a key and MFA
+    # the function should return a string
     metadata: %{
       "placement" => {CatCounter, :venue, []}
     }

--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -21,9 +21,20 @@ defmodule NervesHubLink do
     Socket.check_connection(:device)
   end
 
+  @doc """
+  Checks if the device is connected to the NervesHub console channel.
+  """
   @spec console_connected?() :: boolean()
   def console_connected?() do
     Socket.check_connection(:console)
+  end
+
+  @doc """
+  Checks if the device is connected to the NervesHub extensions channel.
+  """
+  @spec extensions_connected?() :: boolean()
+  def extensions_connected?() do
+    Socket.check_connection(:extensions)
   end
 
   @doc """

--- a/lib/nerves_hub_link/extensions/health/default_report.ex
+++ b/lib/nerves_hub_link/extensions/health/default_report.ex
@@ -78,7 +78,7 @@ defmodule NervesHubLink.Extensions.Health.DefaultReport do
     |> format_metrics_or_metadata()
   end
 
-  def format_metrics_or_metadata(metrics_or_metadata) do
+  defp format_metrics_or_metadata(metrics_or_metadata) do
     metrics_or_metadata
     |> List.wrap()
     |> normalize_metrics_from_config()

--- a/lib/nerves_hub_link/extensions/health/health.ex
+++ b/lib/nerves_hub_link/extensions/health/health.ex
@@ -67,8 +67,10 @@ defmodule NervesHubLink.Extensions.Health do
 
   @impl NervesHubLink.Extensions
   def handle_event("check", _msg, state) do
-    _ = push("report", %{"value" => check_health()})
-    {:noreply, %{state | report_sent: true}}
+    case push("report", %{"value" => check_health()}) do
+      {:ok, _} -> {:noreply, %{state | report_sent: true}}
+      {:error, _reason} -> {:noreply, %{state | report_sent: false}}
+    end
   end
 
   @spec check_health(module()) :: DeviceStatus.t() | nil

--- a/lib/nerves_hub_link/extensions/health/health.ex
+++ b/lib/nerves_hub_link/extensions/health/health.ex
@@ -24,6 +24,7 @@ defmodule NervesHubLink.Extensions.Health do
       :ok
 
   """
+  @spec send_report() :: :ok
   def send_report() do
     GenServer.cast(__MODULE__, "send_report")
   end
@@ -43,6 +44,7 @@ defmodule NervesHubLink.Extensions.Health do
       true
 
   """
+  @spec report_sent?() :: boolean()
   def report_sent?() do
     GenServer.call(__MODULE__, "report_sent?")
   end

--- a/lib/nerves_hub_link/extensions/health/health.ex
+++ b/lib/nerves_hub_link/extensions/health/health.ex
@@ -26,7 +26,7 @@ defmodule NervesHubLink.Extensions.Health do
   """
   @spec send_report() :: :ok
   def send_report() do
-    GenServer.cast(__MODULE__, "send_report")
+    GenServer.cast(__MODULE__, :send_report)
   end
 
   @doc """
@@ -46,7 +46,7 @@ defmodule NervesHubLink.Extensions.Health do
   """
   @spec report_sent?() :: boolean()
   def report_sent?() do
-    GenServer.call(__MODULE__, "report_sent?")
+    GenServer.call(__MODULE__, :report_sent?)
   end
 
   @impl GenServer
@@ -56,12 +56,12 @@ defmodule NervesHubLink.Extensions.Health do
   end
 
   @impl GenServer
-  def handle_cast("send_report", state) do
+  def handle_cast(:send_report, state) do
     handle_event("check", nil, state)
   end
 
   @impl GenServer
-  def handle_call("report_sent?", _args, state) do
+  def handle_call(:report_sent?, _args, state) do
     {:reply, state[:report_sent], state}
   end
 

--- a/lib/nerves_hub_link/extensions/health/metric_set.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set.ex
@@ -3,5 +3,5 @@ defmodule NervesHubLink.Extensions.Health.MetricSet do
   Behaviour for implementing a custom metric set to be used in a report.
   """
 
-  @callback metrics() :: %{(String.t() | atom()) => number()}
+  @callback sample() :: %{(String.t() | atom()) => number()}
 end

--- a/lib/nerves_hub_link/extensions/health/metric_set.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set.ex
@@ -3,5 +3,5 @@ defmodule NervesHubLink.Extensions.Health.MetricSet do
   Behaviour for implementing a custom metric set to be used in a report.
   """
 
-  @callback metrics() :: %{String.t() => number()}
+  @callback metrics() :: %{(String.t() | atom()) => number()}
 end

--- a/lib/nerves_hub_link/extensions/health/metric_set.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set.ex
@@ -1,0 +1,7 @@
+defmodule NervesHubLink.Extensions.Health.MetricSet do
+  @moduledoc """
+  Behaviour for implementing a custom metric set to be used in a report.
+  """
+
+  @callback metrics() :: %{String.t() => number()}
+end

--- a/lib/nerves_hub_link/extensions/health/metric_set/cpu.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/cpu.ex
@@ -1,0 +1,90 @@
+defmodule NervesHubLink.Extensions.Health.MetricSet.CPU do
+  @moduledoc """
+  Health report metrics for CPU temperature, utilization, and load averages.
+
+  The keys used in the report are:
+    - cpu_temp: CPU temperature in Celsius
+    - cpu_usage_percent: CPU utilization percentage
+    - load_1min: Load average over the last minute
+    - load_5min: Load average over the last five minutes
+    - load_15min: Load average over the last fifteen minutes
+  """
+  @behaviour NervesHubLink.Extensions.Health.MetricSet
+
+  @impl NervesHubLink.Extensions.Health.MetricSet
+  def metrics() do
+    [
+      cpu_temperature(),
+      cpu_utilization(),
+      load_averages()
+    ]
+    |> Enum.reduce(%{}, &Map.merge/2)
+  end
+
+  @default_temperature_source "/sys/class/thermal/thermal_zone0/temp"
+  defp cpu_temperature() do
+    cond do
+      match?({:ok, _}, File.stat(@default_temperature_source)) ->
+        with {:ok, content} <- File.read(@default_temperature_source),
+             {millidegree_c, _} <- Integer.parse(content) do
+          %{cpu_temp: millidegree_c / 1000}
+        else
+          _ ->
+            %{}
+        end
+
+      match?({:ok, _}, File.stat("/usr/bin/vcgencmd")) ->
+        cpu_temperature_rpi()
+
+      true ->
+        %{}
+    end
+  end
+
+  defp cpu_utilization() do
+    case Application.ensure_all_started(:os_mon) do
+      {:ok, _} ->
+        cpu_util()
+
+      {:error, {:already_started, _}} ->
+        cpu_util()
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp cpu_util() do
+    case :cpu_sup.util([]) do
+      {:all, usage, _, _} ->
+        %{cpu_usage_percent: usage}
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp cpu_temperature_rpi() do
+    case System.cmd("/usr/bin/vcgencmd", ["measure_temp"]) do
+      {result, 0} ->
+        %{"temp" => temp} = Regex.named_captures(~r/temp=(?<temp>[\d.]+)/, result)
+        {temp, _} = Integer.parse(temp)
+        %{cpu_temp: temp}
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp load_averages() do
+    with {:ok, data_str} <- File.read("/proc/loadavg"),
+         [min1, min5, min15, _, _] <- String.split(data_str, " "),
+         {min1, _} <- Float.parse(min1),
+         {min5, _} <- Float.parse(min5),
+         {min15, _} <- Float.parse(min15) do
+      %{load_1min: min1, load_5min: min5, load_15min: min15}
+    else
+      _ -> %{}
+    end
+  end
+end

--- a/lib/nerves_hub_link/extensions/health/metric_set/cpu.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/cpu.ex
@@ -12,7 +12,7 @@ defmodule NervesHubLink.Extensions.Health.MetricSet.CPU do
   @behaviour NervesHubLink.Extensions.Health.MetricSet
 
   @impl NervesHubLink.Extensions.Health.MetricSet
-  def metrics() do
+  def sample() do
     [
       cpu_temperature(),
       cpu_utilization(),

--- a/lib/nerves_hub_link/extensions/health/metric_set/disk.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/disk.ex
@@ -10,7 +10,7 @@ defmodule NervesHubLink.Extensions.Health.MetricSet.Disk do
   @behaviour NervesHubLink.Extensions.Health.MetricSet
 
   @impl NervesHubLink.Extensions.Health.MetricSet
-  def metrics() do
+  def sample() do
     case Application.ensure_all_started(:os_mon) do
       {:ok, _} ->
         disk_info()

--- a/lib/nerves_hub_link/extensions/health/metric_set/disk.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/disk.ex
@@ -1,0 +1,44 @@
+defmodule NervesHubLink.Extensions.Health.MetricSet.Disk do
+  @moduledoc """
+  Health report metrics for total, available, and used disk space.
+
+  The keys used in the report are:
+    - disk_total_kb: Total disk space in kilobytes
+    - disk_available_kb: Available disk space in kilobytes
+    - disk_used_percentage: Used disk space percentage
+  """
+  @behaviour NervesHubLink.Extensions.Health.MetricSet
+
+  @impl NervesHubLink.Extensions.Health.MetricSet
+  def metrics() do
+    case Application.ensure_all_started(:os_mon) do
+      {:ok, _} ->
+        disk_info()
+
+      {:error, {:already_started, _}} ->
+        disk_info()
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp disk_info() do
+    data =
+      Enum.find(:disksup.get_disk_info(), fn {key, _, _, _} ->
+        key == ~c"/root"
+      end)
+
+    case data do
+      nil ->
+        %{}
+
+      {_, total_kb, available_kb, capacity_percentage} ->
+        %{
+          disk_total_kb: total_kb,
+          disk_available_kb: available_kb,
+          disk_used_percentage: capacity_percentage
+        }
+    end
+  end
+end

--- a/lib/nerves_hub_link/extensions/health/metric_set/memory.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/memory.ex
@@ -10,7 +10,7 @@ defmodule NervesHubLink.Extensions.Health.MetricSet.Memory do
   @behaviour NervesHubLink.Extensions.Health.MetricSet
 
   @impl NervesHubLink.Extensions.Health.MetricSet
-  def metrics() do
+  def sample() do
     {free_output, 0} = System.cmd("free", [])
     [_title_row, memory_row | _] = String.split(free_output, "\n")
     [_title_column | memory_columns] = String.split(memory_row)

--- a/lib/nerves_hub_link/extensions/health/metric_set/memory.ex
+++ b/lib/nerves_hub_link/extensions/health/metric_set/memory.ex
@@ -1,0 +1,27 @@
+defmodule NervesHubLink.Extensions.Health.MetricSet.Memory do
+  @moduledoc """
+  Health report metrics for total, available, and used (percentage) memory.
+
+  The keys used in the report are:
+    - mem_size_mb: Total memory size in megabytes
+    - mem_used_mb: Used memory size in megabytes
+    - mem_used_percent: Used memory percentage
+  """
+  @behaviour NervesHubLink.Extensions.Health.MetricSet
+
+  @impl NervesHubLink.Extensions.Health.MetricSet
+  def metrics() do
+    {free_output, 0} = System.cmd("free", [])
+    [_title_row, memory_row | _] = String.split(free_output, "\n")
+    [_title_column | memory_columns] = String.split(memory_row)
+    [size_kb, used_kb, _, _, _, _] = Enum.map(memory_columns, &String.to_integer/1)
+    size_mb = round(size_kb / 1000)
+    used_mb = round(used_kb / 1000)
+    used_percent = round(used_mb / size_mb * 100)
+
+    %{mem_size_mb: size_mb, mem_used_mb: used_mb, mem_used_percent: used_percent}
+  rescue
+    _ ->
+      %{}
+  end
+end

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -186,13 +186,17 @@ defmodule NervesHubLink.Socket do
     {:ok, socket}
   end
 
+  def handle_call({:check_connection, :device}, _from, socket) do
+    {:reply, joined?(socket, @device_topic), socket}
+  end
+
   @impl Slipstream
   def handle_call({:check_connection, :console}, _from, socket) do
     {:reply, joined?(socket, @console_topic), socket}
   end
 
-  def handle_call({:check_connection, :device}, _from, socket) do
-    {:reply, joined?(socket, @device_topic), socket}
+  def handle_call({:check_connection, :extensions}, _from, socket) do
+    {:reply, joined?(socket, @extensions_topic), socket}
   end
 
   def handle_call({:check_connection, :socket}, _from, socket) do


### PR DESCRIPTION
Introducing the concept of `MetricSet`s.

Metrics are now split into different sets of data which allows device code to specify the metric data they want to send to NervesHub, while also providing a clear and simple way to define custom metrics, or use metric sets from other libs.

I also improved how string keys are normalized. Previously they were being `inspect`ed, which caused extra escaping where it wasn't needed. eg. if the key was "hello", `inspect` would return `"\"hello\""` , which caused `"hello"` to be the key in the metrics UI.

This PR is thanks to @gworkman after seeing how he integrated his boards battery metrics into his Link config.

The `README.md` updates have a good summary of the change, but for the sake of the clear PR, the concept allows for:

```elixir 
config :nerves_hub_link,
  health: [
    metric_sets: [
      :defaults, # expanded within the NervesHubLink.Extensions.Health code
      MyApp.HealthMetrics, # custom app metrics
      ALibrary.BatteryMetrics # metrics from a lib
  ]
```