### PR TITLE
Fix the config key used for fetching the `retry_config`

### DIFF
--- a/lib/nerves_hub_link/downloader/retry_config.ex
+++ b/lib/nerves_hub_link/downloader/retry_config.ex
@@ -1,69 +1,77 @@
+# credo:disable-for-this-file Credo.Check.Readability.StrictModuleLayout
 defmodule NervesHubLink.Downloader.RetryConfig do
-  @moduledoc """
-  Configuration structure for how the Downloader server will
-  handle disconnects, errors, timeouts etc
-  """
-
-  defstruct [
-    # stop trying after this many disconnects
-    max_disconnects: 10,
-
-    # attempt a retry after this time
-    # if no data comes in after this amount of time, disconnect and retry
-    idle_timeout: 60_000,
-
-    # if the total time since this server has started reaches this time,
-    # stop trying, give up, disconnect, etc
-    # started right when the gen_server starts
-    # default is 24 hours as that is how long NervesHub AWS urls are signed for
-    max_timeout: 86_400_000,
-
-    # don't bother retrying until this time has passed
-    time_between_retries: 15_000,
-
-    # worst case average download speed in bits/second
-    # This is used to calculate a "sensible" timeout that is shorter than `max_timeout`.
-    # LTE Cat M1 modems sometimes top out at 32 kbps (30 kbps for some slack)
-    worst_case_download_speed: 30_000
+  @definition [
+    max_disconnects: [
+      doc: """
+      Maximum number of disconnects.
+      After this limit is reached the download will be stopped and will no longer be retried.
+      """,
+      type: :non_neg_integer,
+      default: 10
+    ],
+    idle_timeout: [
+      doc: """
+      Time (in milliseconds) between chunks of data received that once elapsed will trigger a retry.
+      This event counts towards the `max_disconnects` counter.
+      """,
+      type: :non_neg_integer,
+      default: 60_000
+    ],
+    max_timeout: [
+      doc: """
+      Maximum time (in milliseconds) that a download can exist for.
+      After this amount of time has elapsed, the download is canceled and the download process will crash.
+      The default value is 24 hours.
+      """,
+      type: :non_neg_integer,
+      default: 86_400_000
+    ],
+    time_between_retries: [
+      doc: """
+      Time (in milliseconds) to wait before attempting to retry a download.
+      """,
+      type: :non_neg_integer,
+      default: 15_000
+    ],
+    worst_case_download_speed: [
+      doc: """
+      Worst case download speed specified in bytes per second.
+      This is used to calculate the "worst case" ("sensible") download timeout and is
+      intended to fail faster than waiting for `max_timeout` to elapse.
+      For reference, LTE Cat M1 modems sometimes top out at 32 kbps (30 kbps for some slack).
+      """,
+      type: :non_neg_integer,
+      default: 30_000
+    ]
   ]
 
-  @typedoc """
-  maximum number of disconnects. After this limit is reached
-  the download will be stopped and will no longer be retried
-  """
-  @type max_disconnects :: non_neg_integer()
+  @moduledoc """
+  Download retry configuration.
 
-  @typedoc """
-  time in milliseconds between chunks of data received
-  that once elapsed will trigger a retry. This event counts
-  towards the `max_disconnects` counter
-  """
-  @type idle_timeout :: non_neg_integer()
+  This module provides configuration for how the `Downloader` process will
+  handle disconnects, errors, and timeouts.
 
-  @typedoc """
-  maximum time in milliseconds that a download can exist for.
-  after this amount of time has elapsed, the download is canceled
-  and the download process will crash
-  """
-  @type max_timeout :: non_neg_integer()
+  ## Options
 
-  @typedoc """
-  time in milliseconds to wait before attempting to retry a download
+    #{NimbleOptions.docs(@definition)}
   """
-  @type time_between_retries :: non_neg_integer()
 
-  @typedoc """
-  worst case download speed specified in bytes per second. This is
-  used to calculate the "worst case" download timeout. it is meant to
-  fail faster than waiting for `max_timeout` to elapse
-  """
-  @type worst_case_download_speed :: non_neg_integer()
+  defstruct Keyword.keys(@definition)
 
   @type t :: %__MODULE__{
-          max_disconnects: max_disconnects(),
-          idle_timeout: idle_timeout(),
-          max_timeout: max_timeout(),
-          time_between_retries: time_between_retries(),
-          worst_case_download_speed: worst_case_download_speed()
+          max_disconnects: non_neg_integer(),
+          idle_timeout: non_neg_integer(),
+          max_timeout: non_neg_integer(),
+          time_between_retries: non_neg_integer(),
+          worst_case_download_speed: non_neg_integer()
         }
+
+  @doc """
+  Validates a proposed configuration, raising on error
+  """
+  @spec validate!(Keyword.t()) :: t()
+  def validate!(opts) do
+    validated = NimbleOptions.validate!(opts, @definition)
+    struct(__MODULE__, validated)
+  end
 end

--- a/lib/nerves_hub_link/downloader/retry_config.ex
+++ b/lib/nerves_hub_link/downloader/retry_config.ex
@@ -56,6 +56,8 @@ defmodule NervesHubLink.Downloader.RetryConfig do
     #{NimbleOptions.docs(@definition)}
   """
 
+  require Logger
+
   defstruct Keyword.keys(@definition)
 
   @type t :: %__MODULE__{
@@ -71,7 +73,18 @@ defmodule NervesHubLink.Downloader.RetryConfig do
   """
   @spec validate!(Keyword.t()) :: t()
   def validate!(opts) do
-    validated = NimbleOptions.validate!(opts, @definition)
-    struct(__MODULE__, validated)
+    case NimbleOptions.validate(opts, @definition) do
+      {:ok, validated} ->
+        struct(__MODULE__, validated)
+
+      {:error, error} ->
+        Logger.warning("Invalid retry configuration: #{inspect(error)}")
+
+        default = NimbleOptions.validate([], @definition)
+
+        Logger.warning("Using default retry configuration: #{inspect(default)}")
+
+        struct(__MODULE__, default)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -90,6 +90,7 @@ defmodule NervesHubLink.MixProject do
       {:vintage_net, "~> 0.13", optional: true},
       {:nerves_runtime, "~> 0.8"},
       {:nerves_time, "~> 0.4"},
+      {:nimble_options, "~> 1.0"},
       {:plug_crypto, "~> 2.0"},
       {:plug_cowboy, "~> 2.0", only: :test},
       {:slipstream, "~> 1.0 or ~> 0.8"},

--- a/test/nerves_hub_link/downloader_test.exs
+++ b/test/nerves_hub_link/downloader_test.exs
@@ -26,10 +26,7 @@ defmodule NervesHubLink.DownloaderTest do
     test_pid = self()
     handler_fun = &send(test_pid, &1)
 
-    retry_args = %RetryConfig{
-      max_disconnects: 2,
-      time_between_retries: 1
-    }
+    retry_args = RetryConfig.validate!(max_disconnects: 2, time_between_retries: 1)
 
     Process.flag(:trap_exit, true)
     {:ok, download} = Downloader.start_download(@failure_url, handler_fun, retry_args)
@@ -44,9 +41,7 @@ defmodule NervesHubLink.DownloaderTest do
     test_pid = self()
     handler_fun = &send(test_pid, &1)
 
-    retry_args = %RetryConfig{
-      max_timeout: 10
-    }
+    retry_args = RetryConfig.validate!(max_timeout: 10)
 
     Process.flag(:trap_exit, true)
     {:ok, download} = Downloader.start_download(@failure_url, handler_fun, retry_args)
@@ -70,10 +65,11 @@ defmodule NervesHubLink.DownloaderTest do
       test_pid = self()
       handler_fun = &send(test_pid, &1)
 
-      retry_args = %RetryConfig{
-        idle_timeout: 100,
-        time_between_retries: 10
-      }
+      retry_args =
+        RetryConfig.validate!(
+          idle_timeout: 100,
+          time_between_retries: 10
+        )
 
       {:ok, _download} = Downloader.start_download(url, handler_fun, retry_args)
       assert_receive {:error, :idle_timeout}, 1000


### PR DESCRIPTION
**And** improve the docs for the `Downloader` and `RetryConfig` modules.

The retry logic was merged in from a lib called `nerves_hub_link_common` many moons ago, but the key used for fetching the config and the version from the spec were not updated.

This fixes the `User-Agent` header, and aligns how the retry logic should be configured.

I've also given the docs for the `RetryConfig` module a new lick of paint, opting to use [`NimbleOptions`](https://hexdocs.pm/nimble_options).