### PR TITLE
Improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,21 @@
 [![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_link/tree/main.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_link/tree/main)
 [![Hex version](https://img.shields.io/hexpm/v/nerves_hub_link.svg "Hex version")](https://hex.pm/packages/nerves_hub_link)
 
-The Device-side client library for NervesHub.
+`NervesHubLink` is the supported client library for connecting devices to [NervesHub](https://github.com/nerves-hub/nerves_hub_web).
 
-This is the 2.x version NervesHubLink. If you have been using NervesHub prior to around April, 2023 and have not updated to 2.0 or newer see the `maint-v1` branch.
+This integration includes out-of-the-box support for:
 
----
+- firmware updates
+- debug tooling (iex console and support scripts)
+- and device health telemetry
 
 ## Overview
 
-[NervesHub](https://www.nerves-hub.org/) is an open-source IoT fleet management server that is built specifically for Nerves-based devices.
+[NervesHub](https://www.nerves-hub.org/) is an open-source IoT fleet management platform that is built specifically for Nerves-based devices.
 
-Devices connect to the server by joining a long-lived Phoenix channel (for HTTP polling, see [nerves_hub_link_http](https://github.com/nerves-hub/nerves_hub_link_http)). If a firmware update is available, NervesHub will provide a URL to the device and the device can update immediately or [when convenient](https://github.com/nerves-hub/nerves_hub_link#conditionally-applying-updates).
+Devices connect to the server by joining a long-lived websocket channel.
+
+The NervesHub platform helps schedule firmware updates, providing firmware download information to the device which can be applied immediately or [when convenient](https://github.com/nerves-hub/nerves_hub_link#conditionally-applying-updates).
 
 NervesHub does impose some requirements on devices and firmware that may require changes to your Nerves projects:
 
@@ -23,6 +27,12 @@ NervesHub does impose some requirements on devices and firmware that may require
 When using client certificate authentication, each device will also require its own SSL certificate for authentication with NervesHub.
 
 These changes enable NervesHub to provide assurances that the firmware you intend to install on a set of devices make it to those devices unaltered.
+
+> #### Info {: .info}
+>
+> This is the 2.x version of `NervesHubLink`.
+>
+> If you have been using [NervesHub](https://github.com/nerves-hub/nerves_hub_web) prior to around April, 2023 and have not updated to 2.0 or newer, please checkout the `maint-v1` branch.
 
 ## Getting started
 
@@ -49,7 +59,7 @@ project's `mix.exs`. For example:
 
 #### Shared secret device authentication
 
-_Important: Shared Secret authentication is a new feature under active development._
+_Important: Shared Secret authentication tailored for Hobby and R&D projects._
 
 Shared Secrets use [HMAC](https://en.wikipedia.org/wiki/HMAC) cryptography to generate an authentication token used during websocket connection.
 
@@ -125,253 +135,11 @@ For more information on how to generate device certificates, please read the ["I
 
 Any [valid Erlang ssl socket option](http://erlang.org/doc/man/ssl.html#TLS/DTLS%20OPTION%20DESCRIPTIONS%20-%20COMMON%20for%20SERVER%20and%20CLIENT) can go in the `:ssl` key. These options are passed to [Mint](https://hex.pm/packages/mint) by [Slipstream](https://hex.pm/packages/slipstream), which `NervesHubLink` uses for websocket connections.
 
-### Runtime configuration
-
-`NervesHubLink` also supports runtime configuration via the `NervesHubLink.Configurator` behavior. This is called during application startup to build the configuration that is to be used for the connection. When implementing the behavior, you'll receive the initial default config read in from the application environment and you can modify it however you need.
-
-This is useful for cases like:
-
-- selectively choosing which cert/key to use
-- reading a certificate file stored on the device which isn't available during compilation
-
-For example:
-
-```elixir
-defmodule MyApp.Configurator do
-  @behaviour NervesHubLink.Configurator
-
-  @impl NervesHubLink.Configurator
-  def build(config) do
-    ssl = [certfile: "/root/ssl/cert.pem", keyfile: "/root/ssl/key.pem"]
-    %{config | ssl: ssl}
-  end
-end
-```
-
-Then you specify which configurator `NervesHubLink` should use in `config.exs`:
-
-```elixir
-config :nerves_hub_link, configurator: MyApp.Configurator
-```
-
-## Advanced extensions
-
-### Conditionally applying updates
-
-It's not always appropriate to apply a firmware update immediately. Custom logic can be added to the device by implementing the `NervesHubLink.Client` behaviour and telling the NervesHubLink OTP application about it.
-
-Here's an example implementation:
-
-```elixir
-defmodule MyApp.NervesHubLinkClient do
-   @behaviour NervesHubLink.Client
-
-   # May return:
-   #  * `:apply` - apply the action immediately
-   #  * `:ignore` - don't apply the action, don't ask again.
-   #  * `{:reschedule, timeout_in_milliseconds}` - call this function again later.
-
-   @impl NervesHubLink.Client
-   def update_available(data) do
-    if SomeInternalAPI.is_now_a_good_time_to_update?(data) do
-      :apply
-    else
-      {:reschedule, 60_000}
-    end
-   end
-end
-```
-
-To have NervesHubLink invoke it, update your `config.exs` as follows:
-
-```elixir
-config :nerves_hub_link, client: MyApp.NervesHubLinkClient
-```
-
-### Reporting update progress
-
-See the previous section for implementing a `client` behaviour.
-
-```elixir
-defmodule MyApp.NervesHubLinkClient do
-  @behaviour NervesHubLink.Client
-  #  argument can be:
-  #   {:ok, non_neg_integer(), String.t()}
-  #   {:warning, non_neg_integer(), String.t()}
-  #   {:error, non_neg_integer(), String.t()}
-  #   {:progress, 0..100}
-  def handle_fwup_message({:ok, _, _}) do
-    Logger.error("Firmware update complete")
-    :ok
-  end
-
-  def handle_fwup_message({:warning, code, message}) do
-    Logger.error("Warning while applying firmware update (#{code)}): #{message}")
-    :ok
-  end
-
-  def handle_fwup_message({:error, _, message}) do
-    Logger.error("Error while applying firmware update #(#{code}): {message}")
-    :ok
-  end
-
-  def handle_fwup_message({:progress, progress}) when rem(progress, 10) do
-    Logger.info("Update progress: #{progress}%")
-    :ok
-  end
-
-  def handle_fwup_message({:progress, _}) do
-    :ok
-  end
-end
-```
-
-### Enabling remote IEx access
-
-It's possible to remotely log into your device via the NervesHub web interface. This feature is disabled by default. To enable, add the following to your `config.exs`:
-
-```elixir
-config :nerves_hub_link, remote_iex: true
-```
-
-The remote IEx process is started on the first data request from NervesHub and is terminated after 5 minutes of inactivity. You can adjust this by setting `:remote_iex_timeout` value in seconds in your `config.exs`:
-
-```elixir
-config :nerves_hub_link, remote_iex_timeout: 900 # 15 minutes
-```
-
-You may also need additional permissions on NervesHub to see the device and to use the remote IEx feature.
-
-### Alarms
-
-This application can set and clear the following alarms:
-
-- `NervesHubLink.Disconnected`
-  - set: An issue is preventing a connection to NervesHub or one just hasn't been made yet
-  - clear: Currently connected to NervesHub
-- `NervesHubLink.UpdateInProgress`
-  - set: A new firmware update is being downloaded or applied
-  - clear: No updates are happening
-
-### CA Certificates
-
-The CA certificates installed on the device are used by default.
-
-If you include the [CAStore](https://hex.pm/packages/castore) in your project, then that will be selected and used.
-
-Otherwise you can configure `nerves_hub_link` to use custom CA certificates, which is useful if you are running your own NervesHub instance with self signed SSL certificates. Use the `:ca_store` option to specify a module with a `ca_certs/0` function that returns a list of DER encoded certificates:
-
-```elixir
-config :nerves_hub_link, ca_store: MyModule
-```
-
-Or if you have the certificates in DER format, you can also explicitly set them in the :ssl option:
-
-```elixir
-my_der_list = [<<213, 34, 234, 53, 83, 8, 2, ...>>]
-config :nerves_hub_link, ssl: [cacerts: my_der_list]
-```
-
-### Verifying network availability
-
-`NervesHubLink` will attempt to verify that the network is available before initiating the first connection attempt. This is done by checking if the `NervesHub` host address (`config.host`) can be resolved. If the network isn't available then the check will be run again in 2 seconds.
-
-You can disable this behaviour with the following config:
-
-```elixir
-config :nerves_hub_link, connect_wait_for_network: false
-```
-
-### Disable `NervesHubLink` during testing
-
-To disable `NervesHubLink` connecting to `NervesHub` when testing, you can add:
-
-```elixir
-config :nerves_hub_link, connect: false
-```
-
-to your `config/test.exs`
-
-## Extensions: Health & Geo
-
-Extensions are pieces of non-critical functionality going over the NervesHub WebSocket. They are separated out under the Extensions mechanism so that the client can happily ignore anything extension-related in service of keeping firmware updates healthy. That is always the top priority.
-
-There are two extensions currently:
-
-- **Health** reports device metrics, alarms, metadata and similar.
-- **Geo** provides GeoIP information and allows slotting in a better source.
-
-Your NervesHub server controls enabling and disabling extensions to allow you to switch them off if they impact operations.
-
-### Configure Health
-
-You can add your own metrics, metadata and alarms:
-
-In your config.exs for the device:
-
-```
-config :nerves_hub_link,
-  health: [
-    # metrics are added with a key and MFA
-    # the function should return a number (int or float is fine)
-    metrics: %{
-      "cats_passed" => {CatCounter, :total, []}
-    },
-
-    # metadata is identical but should return a string
-    metadata: %{
-      "placement" => {CatCounter, :venue, []}
-    }
-  ]
-```
-
-Or you can implement a completely custom reporting module by implementing `NervesHubLink.Extensions.Health.Report` and configuring it:
-
-```
-config :nerves_hub_link,
-  health: [
-    report: CatCounter.MyHealthReport
-  ]
-```
-
-## Configure Geo
-
-It is intended to be easy to replace the default Geo Resolver with your own. Maybe you have a GPS module or can resolve a reasonably precise location via LTE. Just change config:
-
-```
-config :nerves_hub_link,
-  geo: [
-    resolver: CatCounter.MyResolver
-  ]
-```
-
-Your module only needs to implement a single function, see `NervesHubLink.Extensions.Geo.Resolver` for details.
-
-
-## Configure Alarms
-
-NervesHubLink will automatically report Erlang Alarms from `:alarm_handler` IF you have added a custom alarm handler. The default one is not very helpful and not intended for production use from what I gather. One well-used option is [`alarmist`](https://hex.pm/packages/alarmist).
-
-## Debugging errors
-
-### TLS client errors
-
-If you see the following in your logs:
-
-```text
-14:26:06.926 [info]  ['TLS', 32, 'client', 58, 32, 73, 110, 32, 115, 116, 97, 116, 101, 32, 'cipher', 32, 'received SERVER ALERT: Fatal - Unknown CA', 10]
-```
-
-This probably indicates that the signing certificate hasn't been uploaded to NervesHub so the device can't be authenticated. Double check that you ran:
-
-```sh
-mix nerves_hub.ca_certificate register my-signer.cert
-```
-
-Another possibility is that the device wasn't provisioned with the certificate
-that's on NervesHub.
-
-See also [NervesHubWeb: Potential SSL Issues](https://github.com/nerves-hub/nerves_hub_web#potential-ssl-issues)
+## Additional guides
+
+- [Configuration](guides/configuration.md): Runtime and compile time configuration examples.
+- [Extensions](guides/extensions.md): Setup and configure Health and Geo extensions.
+- [Debugging](guides/debugging.md): Tips to debug connection issues.
 
 ## Internal API Versions
 
@@ -379,12 +147,12 @@ See also [NervesHubWeb: Potential SSL Issues](https://github.com/nerves-hub/nerv
 
 ### `device_api_version`
 
-- `1.0.0` - Updating firmware, status updates, reboot device
-- `2.0.0` - Identify a device, archives
-- `2.1.0` - Run scripts on a device separate from the console, sync firmware keys and archive keys
 - `2.2.0` - Report what extensions are enabled and their version
+- `2.1.0` - Run scripts on a device separate from the console, sync firmware keys and archive keys
+- `2.0.0` - Identify a device, archives
+- `1.0.0` - Updating firmware, status updates, reboot device
 
 ### `console_version`
 
-- `1.0.0` - Remote IEx console
 - `2.0.0` - Send and receive files from a device
+- `1.0.0` - Remote IEx console

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,181 @@
+# Configuration
+
+## Runtime configuration
+
+`NervesHubLink` also supports runtime configuration via the `NervesHubLink.Configurator` behavior. This is called during application startup to build the configuration that is to be used for the connection. When implementing the behavior, you'll receive the initial default config read in from the application environment and you can modify it however you need.
+
+This is useful for cases like:
+
+- selectively choosing which cert/key to use
+- reading a certificate file stored on the device which isn't available during compilation
+
+For example:
+
+```elixir
+defmodule MyApp.Configurator do
+  @behaviour NervesHubLink.Configurator
+
+  @impl NervesHubLink.Configurator
+  def build(config) do
+    ssl = [certfile: "/root/ssl/cert.pem", keyfile: "/root/ssl/key.pem"]
+    %{config | ssl: ssl}
+  end
+end
+```
+
+Then you specify which configurator `NervesHubLink` should use in `config.exs`:
+
+```elixir
+config :nerves_hub_link, configurator: MyApp.Configurator
+```
+
+## Retrying firmware downloads
+
+Firmware and Archive downloads are resilient to network issues and can be retried automatically.
+
+You can configure how the Downloader handles timeouts, disconnections, and other aspects of the
+retry logic by adding the following configuration to your application's config file:
+
+```elixir
+config :nerves_hub_link, :retry_config,
+  max_disconnects: 20,
+  idle_timeout: 75_000,
+  max_timeout: 10_800_000
+```
+
+For more information about the configuration options, see the `NervesHubLink.Downloader.RetryConfig` module.
+
+## Conditionally applying updates
+
+It's not always appropriate to apply a firmware update immediately. Custom logic can be added to the device by
+implementing the `NervesHubLink.Client` behaviour and telling NervesHubLink to use it. eg.
+
+```elixir
+defmodule MyApp.NervesHubLinkClient do
+   @behaviour NervesHubLink.Client
+
+   # May return:
+   #  * `:apply` - apply the action immediately
+   #  * `:ignore` - don't apply the action, don't ask again.
+   #  * `{:reschedule, timeout_in_milliseconds}` - call this function again later.
+
+   @impl NervesHubLink.Client
+   def update_available(data) do
+    if SomeInternalAPI.is_now_a_good_time_to_update?(data) do
+      :apply
+    else
+      {:reschedule, 60_000}
+    end
+   end
+end
+```
+
+To have NervesHubLink use it, update your `config.exs` as follows:
+
+```elixir
+config :nerves_hub_link, client: MyApp.NervesHubLinkClient
+```
+
+## Reporting update progress
+
+See the previous section for implementing a `client` behaviour.
+
+```elixir
+defmodule MyApp.NervesHubLinkClient do
+  @behaviour NervesHubLink.Client
+  #  argument can be:
+  #   {:ok, non_neg_integer(), String.t()}
+  #   {:warning, non_neg_integer(), String.t()}
+  #   {:error, non_neg_integer(), String.t()}
+  #   {:progress, 0..100}
+  def handle_fwup_message({:ok, _, _}) do
+    Logger.error("Firmware update complete")
+    :ok
+  end
+
+  def handle_fwup_message({:warning, code, message}) do
+    Logger.error("Warning while applying firmware update (#{code)}): #{message}")
+    :ok
+  end
+
+  def handle_fwup_message({:error, _, message}) do
+    Logger.error("Error while applying firmware update #(#{code}): {message}")
+    :ok
+  end
+
+  def handle_fwup_message({:progress, progress}) when rem(progress, 10) do
+    Logger.info("Update progress: #{progress}%")
+    :ok
+  end
+
+  def handle_fwup_message({:progress, _}) do
+    :ok
+  end
+end
+```
+
+## Enabling remote IEx access
+
+It's possible to remotely log into your device via the NervesHub web interface. This feature is disabled by default. To enable, add the following to your `config.exs`:
+
+```elixir
+config :nerves_hub_link, remote_iex: true
+```
+
+The remote IEx process is started on the first data request from NervesHub and is terminated after 5 minutes of inactivity. You can adjust this by setting `:remote_iex_timeout` value in seconds in your `config.exs`:
+
+```elixir
+config :nerves_hub_link, remote_iex_timeout: 900 # 15 minutes
+```
+
+You may also need additional permissions on NervesHub to see the device and to use the remote IEx feature.
+
+## Alarms
+
+This application can set and clear the following alarms:
+
+- `NervesHubLink.Disconnected`
+  - set: An issue is preventing a connection to NervesHub or one just hasn't been made yet
+  - clear: Currently connected to NervesHub
+- `NervesHubLink.UpdateInProgress`
+  - set: A new firmware update is being downloaded or applied
+  - clear: No updates are happening
+
+## CA Certificates
+
+The CA certificates installed on the device are used by default.
+
+If you include the [CAStore](https://hex.pm/packages/castore) in your project, then that will be selected and used.
+
+Otherwise you can configure `nerves_hub_link` to use custom CA certificates, which is useful if you are running your own NervesHub instance with self signed SSL certificates. Use the `:ca_store` option to specify a module with a `ca_certs/0` function that returns a list of DER encoded certificates:
+
+```elixir
+config :nerves_hub_link, ca_store: MyModule
+```
+
+Or if you have the certificates in DER format, you can also explicitly set them in the :ssl option:
+
+```elixir
+my_der_list = [<<213, 34, 234, 53, 83, 8, 2, ...>>]
+config :nerves_hub_link, ssl: [cacerts: my_der_list]
+```
+
+## Verifying network availability
+
+`NervesHubLink` will attempt to verify that the network is available before initiating the first connection attempt. This is done by checking if the `NervesHub` host address (`config.host`) can be resolved. If the network isn't available then the check will be run again in 2 seconds.
+
+You can disable this behaviour with the following config:
+
+```elixir
+config :nerves_hub_link, connect_wait_for_network: false
+```
+
+## Disable `NervesHubLink` during testing
+
+To disable `NervesHubLink` connecting to `NervesHub` when testing, you can add:
+
+```elixir
+config :nerves_hub_link, connect: false
+```
+
+to your `config/test.exs`

--- a/guides/debugging.md
+++ b/guides/debugging.md
@@ -1,0 +1,20 @@
+# Debugging
+
+## TLS client errors
+
+If you see the following in your logs:
+
+```text
+14:26:06.926 [info]  ['TLS', 32, 'client', 58, 32, 73, 110, 32, 115, 116, 97, 116, 101, 32, 'cipher', 32, 'received SERVER ALERT: Fatal - Unknown CA', 10]
+```
+
+This probably indicates that the signing certificate hasn't been uploaded to NervesHub so the device can't be authenticated. Double check that you ran:
+
+```sh
+mix nerves_hub.ca_certificate register my-signer.cert
+```
+
+Another possibility is that the device wasn't provisioned with the certificate
+that's on NervesHub.
+
+See also [NervesHubWeb: Potential SSL Issues](https://github.com/nerves-hub/nerves_hub_web#potential-ssl-issues)

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -1,0 +1,59 @@
+# Extensions: Health and Geo
+
+Extensions are pieces of non-critical functionality going over the NervesHub WebSocket. They are separated out under the Extensions mechanism so that the client can happily ignore anything extension-related in service of keeping firmware updates healthy. That is always the top priority.
+
+There are two extensions currently:
+
+- **Health** reports device metrics, alarms, metadata and similar.
+- **Geo** provides GeoIP information and allows slotting in a better source.
+
+Your NervesHub server controls enabling and disabling extensions to allow you to switch them off if they impact operations.
+
+## Health
+
+You can add your own metrics, metadata and alarms:
+
+In your config.exs for the device:
+
+```
+config :nerves_hub_link,
+  health: [
+    # metrics are added with a key and MFA
+    # the function should return a number (int or float is fine)
+    metrics: %{
+      "cats_passed" => {CatCounter, :total, []}
+    },
+
+    # metadata is identical but should return a string
+    metadata: %{
+      "placement" => {CatCounter, :venue, []}
+    }
+  ]
+```
+
+Or you can implement a completely custom reporting module by implementing `NervesHubLink.Extensions.Health.Report` and configuring it:
+
+```
+config :nerves_hub_link,
+  health: [
+    report: CatCounter.MyHealthReport
+  ]
+```
+
+## Geolocation
+
+It is intended to be easy to replace the default Geo Resolver with your own. Maybe you have a GPS module or can resolve a reasonably precise location via LTE. Just change config:
+
+```
+config :nerves_hub_link,
+  geo: [
+    resolver: CatCounter.MyResolver
+  ]
+```
+
+Your module only needs to implement a single function, see `NervesHubLink.Extensions.Geo.Resolver` for details.
+
+
+## Alarms
+
+NervesHubLink will automatically report Erlang Alarms from `:alarm_handler` IF you have added a custom alarm handler. The default one is not very helpful and not intended for production use from what I gather. One well-used option is [`alarmist`](https://hex.pm/packages/alarmist).

--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -43,7 +43,7 @@ defmodule NervesHubLink do
   @doc """
   Current status of the update manager
   """
-  @spec status :: NervesHubLink.UpdateManager.State.status()
+  @spec status :: NervesHubLink.UpdateManager.status()
   defdelegate status(), to: NervesHubLink.UpdateManager
 
   @doc """

--- a/lib/nerves_hub_link/archive_manager.ex
+++ b/lib/nerves_hub_link/archive_manager.ex
@@ -20,6 +20,7 @@ defmodule NervesHubLink.ArchiveManager do
 
   @type status :: :idle | :downloading | :done | :update_rescheduled
 
+  @typedoc false
   @type t :: %__MODULE__{
           archive_info: nil | ArchiveInfo.t(),
           data_path: Path.t(),

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -36,6 +36,8 @@ defmodule NervesHubLink.Client do
   ```
   """
 
+  alias NervesHubLink.Utils.Backoff
+
   require Logger
 
   @typedoc "Update that comes over a socket."
@@ -101,8 +103,8 @@ defmodule NervesHubLink.Client do
   @doc """
   Optional callback when the socket disconnected, before starting to reconnect.
 
-  The return value is used to reset the next socket's retry timeout. `nil` uses
-  the default. The default is a call to `NervesHubLink.Backoff.delay_list/3`.
+  The return value is used to reset the next socket's retry timeout. `nil` asks NervesHubLink
+  to calculate a set of random backoffs to use.
 
   You may wish to use this to dynamically change the reconnect backoffs. For instance,
   during a NervesHub deploy you may wish to change the reconnect based on your
@@ -238,7 +240,7 @@ defmodule NervesHubLink.Client do
     if is_list(backoff) do
       backoff
     else
-      NervesHubLink.Backoff.delay_list(1000, 60000, 0.50)
+      Backoff.delay_list(1000, 60000, 0.50)
     end
   end
 

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -12,7 +12,7 @@ defmodule NervesHubLink.Configurator do
 
   alias __MODULE__.Config
   alias Nerves.Runtime.KV
-  alias NervesHubLink.Backoff
+  alias NervesHubLink.Utils.Backoff
 
   require Logger
 

--- a/lib/nerves_hub_link/configurators/local_cert_key.ex
+++ b/lib/nerves_hub_link/configurators/local_cert_key.ex
@@ -6,7 +6,8 @@ defmodule NervesHubLink.Configurator.LocalCertKey do
   @behaviour NervesHubLink.Configurator
 
   alias Nerves.Runtime.KV
-  alias NervesHubLink.{Certificate, Configurator.Config}
+  alias NervesHubLink.Configurator.Config
+  alias NervesHubLink.Utils.Certificate
 
   @cert_kv_path "nerves_hub_cert"
   @key_kv_path "nerves_hub_key"

--- a/lib/nerves_hub_link/configurators/nerves_key.ex
+++ b/lib/nerves_hub_link/configurators/nerves_key.ex
@@ -7,7 +7,8 @@ if Code.ensure_loaded?(NervesKey) do
     @behaviour NervesHubLink.Configurator
 
     alias ATECC508A.Transport.I2C
-    alias NervesHubLink.{Certificate, Configurator.Config}
+    alias NervesHubLink.Configurator.Config
+    alias NervesHubLink.Utils.Certificate
     alias NervesKey.PKCS11
 
     @impl NervesHubLink.Configurator

--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -5,8 +5,8 @@ defmodule NervesHubLink.Configurator.SharedSecret do
   @behaviour NervesHubLink.Configurator
 
   alias Nerves.Runtime.KV
-  alias NervesHubLink.Certificate
   alias NervesHubLink.Configurator.Config
+  alias NervesHubLink.Utils.Certificate
 
   @impl NervesHubLink.Configurator
   def build(%Config{ssl: ssl, socket: socket} = config) do

--- a/lib/nerves_hub_link/downloader.ex
+++ b/lib/nerves_hub_link/downloader.ex
@@ -109,7 +109,7 @@ defmodule NervesHubLink.Downloader do
   def start_download(url, fun) when is_function(fun, 1) do
     retry_config =
       Application.get_env(:nerves_hub_link, :retry_config, [])
-      |> RetryConfig.validate!()
+      |> RetryConfig.validate()
 
     GenServer.start_link(__MODULE__, [URI.parse(url), fun, retry_config])
   end

--- a/lib/nerves_hub_link/downloader/retry_config.ex
+++ b/lib/nerves_hub_link/downloader/retry_config.ex
@@ -69,10 +69,10 @@ defmodule NervesHubLink.Downloader.RetryConfig do
         }
 
   @doc """
-  Validates a proposed configuration, raising on error
+  Validates a proposed configuration, returning the default configuration on error
   """
-  @spec validate!(Keyword.t()) :: t()
-  def validate!(opts) do
+  @spec validate(Keyword.t()) :: t()
+  def validate(opts) do
     case NimbleOptions.validate(opts, @definition) do
       {:ok, validated} ->
         struct(__MODULE__, validated)

--- a/lib/nerves_hub_link/downloader/timeout_calculation.ex
+++ b/lib/nerves_hub_link/downloader/timeout_calculation.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubLink.Downloader.TimeoutCalculation do
-  @moduledoc """
-  Pure functions for dealing with timeouts
-  """
+  @moduledoc false
+
+  # Pure functions for dealing with timeouts
 
   @type number_of_bytes :: non_neg_integer()
   @type bits_per_second :: non_neg_integer()

--- a/lib/nerves_hub_link/fwup_config.ex
+++ b/lib/nerves_hub_link/fwup_config.ex
@@ -1,7 +1,10 @@
 defmodule NervesHubLink.FwupConfig do
   @moduledoc """
-  Config structure responsible for handling callbacks from FWUP,
-  applying a fwupdate, and storing fwup task configuration
+  Config structure responsible for:
+
+  - handling callbacks from FWUP
+  - applying a fwupdate,
+  - and storing fwup task configuration
   """
   alias NervesHubLink.Message.UpdateInfo
 

--- a/lib/nerves_hub_link/message/archive_info.ex
+++ b/lib/nerves_hub_link/message/archive_info.ex
@@ -1,5 +1,7 @@
 defmodule NervesHubLink.Message.ArchiveInfo do
-  @moduledoc false
+  @moduledoc """
+  Payload received from NervesHub when an archive is available.
+  """
 
   defstruct [
     :architecture,
@@ -12,9 +14,6 @@ defmodule NervesHubLink.Message.ArchiveInfo do
     :version
   ]
 
-  @typedoc """
-  Payload that gets dispatched down to devices upon an archive being available
-  """
   @type t() :: %__MODULE__{
           architecture: String.t(),
           description: String.t(),
@@ -26,8 +25,8 @@ defmodule NervesHubLink.Message.ArchiveInfo do
           version: Version.t()
         }
 
-  @doc "Parse an update message from NervesHub"
-  @spec parse(map()) :: {:ok, t()}
+  @doc "Parse an update message from NervesHub."
+  @spec parse(message :: map()) :: {:ok, t()}
   def parse(params) do
     {:ok,
      %__MODULE__{

--- a/lib/nerves_hub_link/message/firmware_metadata.ex
+++ b/lib/nerves_hub_link/message/firmware_metadata.ex
@@ -1,6 +1,6 @@
 defmodule NervesHubLink.Message.FirmwareMetadata do
   @moduledoc """
-  Structure containing metadata about a firmware.
+  Detailed firmware metadata received during the firmware update process.
   """
 
   defstruct [
@@ -29,7 +29,7 @@ defmodule NervesHubLink.Message.FirmwareMetadata do
           version: Version.build()
         }
 
-  @spec parse(map()) :: {:ok, t()}
+  @spec parse(metadata :: map()) :: {:ok, t()}
   def parse(params) do
     {:ok,
      %__MODULE__{

--- a/lib/nerves_hub_link/message/update_info.ex
+++ b/lib/nerves_hub_link/message/update_info.ex
@@ -1,23 +1,19 @@
 defmodule NervesHubLink.Message.UpdateInfo do
-  @moduledoc false
+  @moduledoc """
+  Payload received from NervesHub when an update is available.
+  """
 
   alias NervesHubLink.Message.FirmwareMetadata
 
   defstruct [:firmware_url, :firmware_meta]
 
-  @typedoc """
-  Payload that gets dispatched down to devices upon an update
-
-  `firmware_url` and `firmware_meta` are only available
-  when `update_available` is true.
-  """
   @type t() :: %__MODULE__{
           firmware_url: URI.t(),
           firmware_meta: FirmwareMetadata.t()
         }
 
-  @doc "Parse an update message from NervesHub"
-  @spec parse(map()) :: {:ok, t()} | {:error, :invalid_params}
+  @doc "Parse an update message from NervesHub."
+  @spec parse(message :: map()) :: {:ok, t()} | {:error, :invalid_params}
   def parse(%{"firmware_meta" => %{} = meta, "firmware_url" => url}) do
     with {:ok, firmware_meta} <- FirmwareMetadata.parse(meta) do
       {:ok,

--- a/lib/nerves_hub_link/script.ex
+++ b/lib/nerves_hub_link/script.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubLink.Script do
-  @moduledoc """
-  Mechanism for running scripts from NervesHub on device.
-  """
+  @moduledoc false
+
+  # Mechanism for running scripts from NervesHub on device.
 
   use GenServer
 

--- a/lib/nerves_hub_link/utils/backoff.ex
+++ b/lib/nerves_hub_link/utils/backoff.ex
@@ -1,7 +1,7 @@
-defmodule NervesHubLink.Backoff do
-  @moduledoc """
-  Compute retry backoff intervals used by Slipstream
-  """
+defmodule NervesHubLink.Utils.Backoff do
+  @moduledoc false
+
+  # Compute retry backoff intervals used by Slipstream
 
   @doc """
   Produce a list of integer backoff delays with jitter

--- a/lib/nerves_hub_link/utils/certificate.ex
+++ b/lib/nerves_hub_link/utils/certificate.ex
@@ -1,7 +1,7 @@
-defmodule NervesHubLink.Certificate do
-  @moduledoc """
-  Certificate management utilities.
-  """
+defmodule NervesHubLink.Utils.Certificate do
+  @moduledoc false
+
+  # Certificate management utilities.
 
   require Logger
 

--- a/mix.exs
+++ b/mix.exs
@@ -52,11 +52,57 @@ defmodule NervesHubLink.MixProject do
 
   defp docs do
     [
-      extras: ["README.md", "CHANGELOG.md"],
+      extras: [
+        "README.md",
+        "guides/configuration.md": [title: "Configuration"],
+        "guides/extensions.md": [title: "Extensions"],
+        "guides/debugging.md": [title: "Debugging"],
+        "CHANGELOG.md": [title: "Changelog"]
+      ],
       main: "readme",
       source_ref: "v#{@version}",
       source_url: @source_url,
-      skip_undefined_reference_warnings_on: ["CHANGELOG.md"]
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
+      groups_for_extras: [
+        Guides: Path.wildcard("guides/*.md")
+      ],
+      groups_for_modules: [
+        Client: [
+          NervesHubLink.Client,
+          NervesHubLink.Client.Default
+        ],
+        Configuration: [
+          NervesHubLink.Configurator,
+          NervesHubLink.Configurator.Config,
+          NervesHubLink.Configurator.LocalCertKey,
+          NervesHubLink.Configurator.NervesKey,
+          NervesHubLink.Configurator.SharedSecret,
+          NervesHubLink.FwupConfig
+        ],
+        Extensions: [
+          NervesHubLink.Extensions,
+          NervesHubLink.Extensions.Geo,
+          NervesHubLink.Extensions.Geo.DefaultResolver,
+          NervesHubLink.Extensions.Geo.Resolver,
+          NervesHubLink.Extensions.Health,
+          NervesHubLink.Extensions.Health.DefaultReport,
+          NervesHubLink.Extensions.Health.DeviceStatus,
+          NervesHubLink.Extensions.Health.Report
+        ],
+        "Downloads and Updates": [
+          NervesHubLink.UpdateManager,
+          NervesHubLink.UpdateManager.State,
+          NervesHubLink.ArchiveManager,
+          NervesHubLink.Downloader,
+          NervesHubLink.Downloader.RetryConfig,
+          NervesHubLink.Downloader.TimeoutCalculation
+        ],
+        "NervesHub Messages": [
+          NervesHubLink.Message.ArchiveInfo,
+          NervesHubLink.Message.FirmwareMetadata,
+          NervesHubLink.Message.UpdateInfo
+        ]
+      ]
     ]
   end
 

--- a/test/nerves_hub_link/backoff_test.exs
+++ b/test/nerves_hub_link/backoff_test.exs
@@ -1,6 +1,6 @@
 defmodule NervesHubLink.BackoffTest do
   use ExUnit.Case, async: true
-  alias NervesHubLink.Backoff
+  alias NervesHubLink.Utils.Backoff
 
   test "no jitter" do
     assert Backoff.delay_list(1000, 60000, 0) == [1000, 2000, 4000, 8000, 16000, 32000, 60000]

--- a/test/nerves_hub_link/certificate_test.exs
+++ b/test/nerves_hub_link/certificate_test.exs
@@ -1,6 +1,6 @@
 defmodule NervesHubLink.CertificateTest do
   use ExUnit.Case, async: true
-  alias NervesHubLink.Certificate
+  alias NervesHubLink.Utils.Certificate
 
   doctest Certificate
 

--- a/test/nerves_hub_link/downloader_test.exs
+++ b/test/nerves_hub_link/downloader_test.exs
@@ -26,7 +26,7 @@ defmodule NervesHubLink.DownloaderTest do
     test_pid = self()
     handler_fun = &send(test_pid, &1)
 
-    retry_args = RetryConfig.validate!(max_disconnects: 2, time_between_retries: 1)
+    retry_args = RetryConfig.validate(max_disconnects: 2, time_between_retries: 1)
 
     Process.flag(:trap_exit, true)
     {:ok, download} = Downloader.start_download(@failure_url, handler_fun, retry_args)
@@ -41,7 +41,7 @@ defmodule NervesHubLink.DownloaderTest do
     test_pid = self()
     handler_fun = &send(test_pid, &1)
 
-    retry_args = RetryConfig.validate!(max_timeout: 10)
+    retry_args = RetryConfig.validate(max_timeout: 10)
 
     Process.flag(:trap_exit, true)
     {:ok, download} = Downloader.start_download(@failure_url, handler_fun, retry_args)
@@ -66,7 +66,7 @@ defmodule NervesHubLink.DownloaderTest do
       handler_fun = &send(test_pid, &1)
 
       retry_args =
-        RetryConfig.validate!(
+        RetryConfig.validate(
           idle_timeout: 100,
           time_between_retries: 10
         )


### PR DESCRIPTION
- Extract some of the readme into guides
- Remove some module documentation to reduce unnecessary docs
- Move a few modules into a `utils` dir
- and updated the Readme to read a little nicer

This is built on top of #280, which should be merged in first.