### PR TITLE
Emit a warning when trying to retrieve public certs through Erlang on < OTP 25

### DIFF
--- a/lib/nerves_hub_link/certificate.ex
+++ b/lib/nerves_hub_link/certificate.ex
@@ -64,7 +64,21 @@ defmodule NervesHubLink.Certificate do
           "[NervesHubLink] Using default system certificates. Requests may fail if the NervesHub server certificate is not signed by a globally trusted CA, or the installed system certificates are old."
         )
 
-        :public_key.cacerts_get()
+        maybe_public_certs()
+    end
+  end
+
+  # TODO: We can drop this check once OTP 25
+  # is our lowest supported version
+  if String.to_integer(System.otp_release()) >= 25 do
+    defp maybe_public_certs(), do: :public_key.cacerts_get()
+  else
+    defp maybe_public_certs() do
+      Logger.debug(
+        "[NervesHubLink] Cannot retrieve public certs without CAStore on OTP 24 and below. Please add it as a dependency: https://hex.pm/packages/castore."
+      )
+
+      []
     end
   end
 end


### PR DESCRIPTION
This lets us compile with no warnings on OTP 24. Solves #292.

Credo complains about using `apply/3` when knowing the number of arguments, but I think it's usage is appropriate here.