### PR TITLE
Add a client callback for when the device is connected

### DIFF
--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -70,6 +70,13 @@ defmodule NervesHubLink.Client do
           | {:progress, 0..100}
 
   @doc """
+  Called when the connection to NervesHub has been established.
+
+  The return value of this function is not checked.
+  """
+  @callback connected() :: any
+
+  @doc """
   Called to find out what to do when a firmware update is available.
 
   May return one of:
@@ -139,6 +146,11 @@ defmodule NervesHubLink.Client do
   @callback reboot() :: no_return()
 
   @optional_callbacks [reconnect_backoff: 0, reboot: 0]
+
+  @spec connected() :: any
+  def connected do
+    apply_wrap(mod(), :connected, [])
+  end
 
   @doc """
   This function is called internally by NervesHubLink to notify clients.

--- a/lib/nerves_hub_link/client/default.ex
+++ b/lib/nerves_hub_link/client/default.ex
@@ -21,6 +21,11 @@ defmodule NervesHubLink.Client.Default do
   require Logger
 
   @impl NervesHubLink.Client
+  def connected do
+    :ok
+  end
+
+  @impl NervesHubLink.Client
   def update_available(update_info) do
     if update_info.firmware_meta.uuid == KV.get_active("nerves_fw_uuid") do
       Logger.info("""

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -176,6 +176,9 @@ defmodule NervesHubLink.Socket do
       |> assign(connected_at: System.monotonic_time(:millisecond))
 
     :alarm_handler.clear_alarm(NervesHubLink.Disconnected)
+
+    Client.connected()
+
     {:ok, socket}
   end
 

--- a/test/nerves_hub_link/client/default_test.exs
+++ b/test/nerves_hub_link/client/default_test.exs
@@ -20,6 +20,10 @@ defmodule NervesHubLink.Client.DefaultTest do
     firmware_meta: %FirmwareMetadata{}
   }
 
+  test "connected/0" do
+    assert Default.connected() == :ok
+  end
+
   test "update_available/1" do
     assert Default.update_available(@update_info) == :apply
   end

--- a/test/nerves_hub_link/client_test.exs
+++ b/test/nerves_hub_link/client_test.exs
@@ -18,6 +18,11 @@ defmodule NervesHubLink.ClientTest do
     Mox.verify_on_exit!(context)
   end
 
+  test "connected/0" do
+    Mox.expect(ClientMock, :connected, fn -> :ok end)
+    assert Client.connected() == :ok
+  end
+
   test "update_available/2" do
     Mox.expect(ClientMock, :update_available, fn :data -> :apply end)
     assert Client.update_available(:data) == :apply


### PR DESCRIPTION
We needed a place to call `Nerves.Runtime.validate_firmware` when a connection is established to Nerves Hub, and it seemed like a callback in `Client` would be the best place for this. We did consider polling `NervesHubLink.connected?`, but this felt wrong since NervesHubLink has the `Client` handlers.

Although we're validating firmware in a custom handler, I implemented the NervesHubLink default handler as a no-op so it doesn't impact anyone. However, if it ever became the Nerves default to have [nerves_fw_autovalidate](https://github.com/nerves-project/nerves_system_bbb/blob/a774df9d83a667578cf2d2558a61d7c79cd642e2/uboot/uboot.env#L45-L49) disabled, this would be a convenient place for everyone's cloud-connected firmware to be validated by default. 😉