### PR TITLE
Support the default `:alarm_handler` in the health report

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,15 +10,8 @@
       "addWords": false
     }
   ],
-  "dictionaries": [
-    "elixir", 
-    "fhunleth-cspell-dictionary"
-  ],
-  "ignorePaths": [
-    "**/*.yml",
-    "mix.exs",
-    "LICENSES"
-  ],
+  "dictionaries": ["elixir", "fhunleth-cspell-dictionary"],
+  "ignorePaths": ["**/*.yml", "mix.exs", "LICENSES", "CHANGELOG.md"],
   "words": [
     // Contributor names
     "arellano",
@@ -42,6 +35,6 @@
     "reconnections",
     "subkey",
     "vcgencmd",
-    "whenwhere",
+    "whenwhere"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+* Added
+  * Add a client callback for when the device is connected (#312) (Thanks @amclain)
+
+* Updated
+  * Don't create duplicate Disconnected alarms
+  * Clear previous `CheckFailed` alarms before setting a new one
+  * Support the use of `:alarm_handler` for health reports, removing the `Alarmist` requirement
+
 ## [2.7.3] - 2025-04-15
 
 * Fixed

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -102,8 +102,5 @@ Your module only needs to implement a single function, see `NervesHubLink.Extens
 
 ## Alarms
 
-The [default health report](`NervesHubLink.Extensions.Health.DefaultReport`) requires the use of
-the [`alarmist`](https://hex.pm/packages/alarmist) library for correct alarms handling.
-
-To use another handler, you will need to create a custom [health report](`NervesHubLink.Extensions.Health.Report`)
-which implements the [`alarms/0`](`c:NervesHubLink.Extensions.Health.Report.alarms/0`) callback.
+The [default health report](`NervesHubLink.Extensions.Health.DefaultReport`) uses `:alarm_handler`, but we
+recommend the [`alarmist`](https://hex.pm/packages/alarmist) library for improved alarms handling.

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -23,8 +23,6 @@ defmodule NervesHubLink.Application do
   def start(_type, _args) do
     connect? = Application.get_env(:nerves_hub_link, :connect, true)
 
-    maybe_create_firmware_reverted_alarm()
-
     children =
       if connect? do
         config = Configurator.build()
@@ -49,13 +47,5 @@ defmodule NervesHubLink.Application do
       end
 
     Supervisor.start_link(children, strategy: :one_for_one, name: NervesHubLink.Supervisor)
-  end
-
-  defp maybe_create_firmware_reverted_alarm() do
-    if KV.get("nerves_fw_reverted") == "true" do
-      :alarm_handler.set_alarm({Nerves.FirmwareReverted, []})
-    end
-
-    :ok
   end
 end

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -17,8 +17,6 @@ defmodule NervesHubLink.Application do
   alias NervesHubLink.Socket
   alias NervesHubLink.UpdateManager
 
-  alias Nerves.Runtime.KV
-
   @impl Application
   def start(_type, _args) do
     connect? = Application.get_env(:nerves_hub_link, :connect, true)

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -21,6 +21,8 @@ defmodule NervesHubLink.Application do
   def start(_type, _args) do
     connect? = Application.get_env(:nerves_hub_link, :connect, true)
 
+    maybe_create_firmware_reverted_alarm()
+
     children =
       if connect? do
         config = Configurator.build()
@@ -45,5 +47,13 @@ defmodule NervesHubLink.Application do
       end
 
     Supervisor.start_link(children, strategy: :one_for_one, name: NervesHubLink.Supervisor)
+  end
+
+  def maybe_create_firmware_reverted_alarm() do
+    if Nerves.Runtime.KV.get("nerves_fw_reverted") == "true" do
+      :alarm_handler.set_alarm({Nerves.FirmwareReverted, []})
+    end
+
+    :ok
   end
 end

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -17,6 +17,8 @@ defmodule NervesHubLink.Application do
   alias NervesHubLink.Socket
   alias NervesHubLink.UpdateManager
 
+  alias Nerves.Runtime.KV
+
   @impl Application
   def start(_type, _args) do
     connect? = Application.get_env(:nerves_hub_link, :connect, true)
@@ -49,8 +51,8 @@ defmodule NervesHubLink.Application do
     Supervisor.start_link(children, strategy: :one_for_one, name: NervesHubLink.Supervisor)
   end
 
-  def maybe_create_firmware_reverted_alarm() do
-    if Nerves.Runtime.KV.get("nerves_fw_reverted") == "true" do
+  defp maybe_create_firmware_reverted_alarm() do
+    if KV.get("nerves_fw_reverted") == "true" do
       :alarm_handler.set_alarm({Nerves.FirmwareReverted, []})
     end
 

--- a/lib/nerves_hub_link/extensions/health/default_report.ex
+++ b/lib/nerves_hub_link/extensions/health/default_report.ex
@@ -37,20 +37,28 @@ defmodule NervesHubLink.Extensions.Health.DefaultReport do
   if Code.ensure_loaded?(Alarmist) do
     @impl Report
     def alarms() do
-      for {id, description} <- Alarmist.get_alarms(), into: %{} do
-        try do
-          {inspect(id), inspect(description)}
-        catch
-          _, _ ->
-            {"bad alarm term", ""}
-        end
-      end
+      Alarmist.get_alarms()
+      |> filter_and_format_alarms()
     end
   else
     @impl Report
     def alarms() do
-      %{}
+      :alarm_handler.get_alarms()
+      |> filter_and_format_alarms()
     end
+  end
+
+  defp filter_and_format_alarms(alarms) do
+    alarms
+    |> Enum.reject(fn {id, _} -> id == {:disk_almost_full, ~c"/"} end)
+    |> Enum.into(%{}, fn {id, description} ->
+      try do
+        {inspect(id), inspect(description)}
+      catch
+        _, _ ->
+          {"bad alarm term", ""}
+      end
+    end)
   end
 
   @impl Report

--- a/lib/nerves_hub_link/extensions/health/default_report.ex
+++ b/lib/nerves_hub_link/extensions/health/default_report.ex
@@ -33,7 +33,12 @@ defmodule NervesHubLink.Extensions.Health.DefaultReport do
     metadata_from_config()
   end
 
-  # The Alarmist library is required for alarms handling.
+  @doc """
+  The alarm callback will use `Alarmist`, if it is available,
+  otherwise it will default to `:alarm_handler`.
+  """
+  def alarms()
+
   if Code.ensure_loaded?(Alarmist) do
     @impl Report
     def alarms() do

--- a/lib/nerves_hub_link/extensions/health/health.ex
+++ b/lib/nerves_hub_link/extensions/health/health.ex
@@ -117,6 +117,7 @@ defmodule NervesHubLink.Extensions.Health do
         end
 
       Logger.error("Health check failed due to error: #{reason}")
+      :alarm_handler.clear_alarm(NervesHubLink.Extensions.Health.CheckFailed)
       :alarm_handler.set_alarm({NervesHubLink.Extensions.Health.CheckFailed, [reason: reason]})
 
       DeviceStatus.new(

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -107,7 +107,7 @@ defmodule NervesHubLink.Socket do
 
   @impl Slipstream
   def init(config) do
-    :alarm_handler.set_alarm({NervesHubLink.Disconnected, []})
+    set_disconnected_alarm()
 
     socket =
       new_socket()
@@ -175,7 +175,7 @@ defmodule NervesHubLink.Socket do
       |> maybe_join_console()
       |> assign(connected_at: System.monotonic_time(:millisecond))
 
-    :alarm_handler.clear_alarm(NervesHubLink.Disconnected)
+    clear_disconnected_alarm()
 
     Client.connected()
 
@@ -574,6 +574,20 @@ defmodule NervesHubLink.Socket do
   @impl Slipstream
   def terminate(_reason, socket) do
     disconnect(socket)
+  end
+
+  defp set_disconnected_alarm() do
+    if !Enum.any?(:alarm_handler.get_alarms(), &(elem(&1, 0) == NervesHubLink.Disconnected)) do
+      :alarm_handler.set_alarm({NervesHubLink.Disconnected, []})
+    end
+
+    :ok
+  end
+
+  defp clear_disconnected_alarm() do
+    :alarm_handler.clear_alarm(NervesHubLink.Disconnected)
+
+    :ok
   end
 
   defp schedule_network_availability_check(delay \\ 100) do


### PR DESCRIPTION
This PR adds support for the default `:alarm_handler` in health reports.

I've also made sure we don't create duplicate `Disconnected` alarms.

And while I was here, I have cleared previous `CheckFailed` alarms before setting a new one.

Oh, I also filter out the `{:disk_almost_full, ~c"/"}` alarm as this is just a byproduct of the read-only file system.

