### PR TITLE
Add opt-in support for websocket `permessage-deflate`

### DIFF
--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -36,6 +36,7 @@ defmodule NervesHubLink.Configurator do
     """
 
     defstruct archive_public_keys: [],
+              compress: false,
               connect: true,
               connect_wait_for_network: true,
               data_path: "/data/nerves-hub",
@@ -60,6 +61,7 @@ defmodule NervesHubLink.Configurator do
 
     @type t() :: %__MODULE__{
             archive_public_keys: [binary()],
+            compress: boolean(),
             connect: boolean(),
             connect_wait_for_network: boolean(),
             data_path: Path.t(),

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -36,7 +36,7 @@ defmodule NervesHubLink.Configurator do
     """
 
     defstruct archive_public_keys: [],
-              compress: false,
+              compress: true,
               connect: true,
               connect_wait_for_network: true,
               data_path: "/data/nerves-hub",

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -136,15 +136,9 @@ defmodule NervesHubLink.Socket do
 
     rejoin_after = Application.get_env(:nerves_hub_link, :rejoin_after, 5_000)
 
-    mint_opts =
-      if config.socket[:url].scheme == "wss" do
-        [protocols: [:http1], transport_opts: config.ssl]
-      else
-        [protocols: [:http1]]
-      end
-
     opts = [
-      mint_opts: mint_opts,
+      mint_opts: mint_opts(config),
+      extensions: mint_extensions(config),
       headers: config.socket[:headers] || [],
       uri: config.socket[:url],
       rejoin_after_msec: [rejoin_after],
@@ -574,6 +568,22 @@ defmodule NervesHubLink.Socket do
   @impl Slipstream
   def terminate(_reason, socket) do
     disconnect(socket)
+  end
+
+  defp mint_opts(config) do
+    if config.socket[:url].scheme == "wss" do
+      [protocols: [:http1], transport_opts: config.ssl]
+    else
+      [protocols: [:http1]]
+    end
+  end
+
+  defp mint_extensions(config) do
+    if config.compress do
+      [Mint.WebSocket.PerMessageDeflate]
+    else
+      []
+    end
   end
 
   defp schedule_network_availability_check(delay \\ 100) do


### PR DESCRIPTION
Although we have set `compress: true` for the sockets defined in the `DeviceEndpoint`s in NervesHub, we also need to enable it in the client so it can be negotiated.

This PR adds opt-out support for compression, with compression on by default.