### PR TITLE
Fixed the issue where default cacerts would override cacertfile option

### DIFF
--- a/lib/nerves_hub_link/configurators/local_cert_key.ex
+++ b/lib/nerves_hub_link/configurators/local_cert_key.ex
@@ -27,7 +27,14 @@ defmodule NervesHubLink.Configurator.LocalCertKey do
   end
 
   defp maybe_add_cacerts(%{ssl: ssl} = config) do
-    %{config | ssl: Keyword.put_new(ssl, :cacerts, Certificate.ca_certs())}
+    ssl =
+      if ssl[:cacerts] || ssl[:cacertfile] do
+        ssl
+      else
+        Keyword.put_new(ssl, :cacerts, Certificate.ca_certs())
+      end
+
+    %{config | ssl: ssl}
   end
 
   defp maybe_add_cert(%{ssl: ssl} = config) do

--- a/lib/nerves_hub_link/configurators/local_cert_key.ex
+++ b/lib/nerves_hub_link/configurators/local_cert_key.ex
@@ -27,14 +27,11 @@ defmodule NervesHubLink.Configurator.LocalCertKey do
   end
 
   defp maybe_add_cacerts(%{ssl: ssl} = config) do
-    ssl =
-      if ssl[:cacerts] || ssl[:cacertfile] do
-        ssl
-      else
-        Keyword.put_new(ssl, :cacerts, Certificate.ca_certs())
-      end
-
-    %{config | ssl: ssl}
+    if ssl[:cacerts] || ssl[:cacertfile] do
+      config
+    else
+      %{config | ssl: Keyword.put(ssl, :cacerts, Certificate.ca_certs())}
+    end
   end
 
   defp maybe_add_cert(%{ssl: ssl} = config) do

--- a/test/nerves_hub_link/configurators/local_cert_key_test.exs
+++ b/test/nerves_hub_link/configurators/local_cert_key_test.exs
@@ -22,6 +22,17 @@ defmodule NervesHubLink.Configurator.DefaultTest do
     assert new_config.ssl == config.ssl
   end
 
+  test "doesn't add cacerts when cacertfile is provided" do
+    config = %Config{
+      ssl: [
+        cacertfile: ~c"/cacert.pem"
+      ]
+    }
+
+    new_config = LocalCertKey.build(config)
+    refute new_config.ssl[:cacerts]
+  end
+
   test "reads values from Nerves.Runtime.KV" do
     config = LocalCertKey.build(%Config{})
 


### PR DESCRIPTION
The `LocalCertKey` configurator was always adding `cacerts`, even when `cacertfile` was provided.

The issue with that is the fact that `ssl` will ignore `cacertfile` option if `cacerts` is present, hence you will not be able to set that option at all.