### PR TITLE
A new firmware update workflow orchestrator

### DIFF
--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -33,10 +33,15 @@ defmodule NervesHubLink.Application do
           update_available: &Client.update_available/1
         }
 
+        downloader_config = %{
+          cache_firmware_to_disk: config.cache_firmware_to_disk,
+          cache_firmware_dir: config.cache_firmware_dir
+        }
+
         [
           {DynamicSupervisor, name: ExtensionsSupervisor},
           Extensions,
-          {UpdateManager, fwup_config},
+          {UpdateManager, {fwup_config, downloader_config}},
           {ArchiveManager, config},
           {Socket, config}
         ]

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -33,15 +33,10 @@ defmodule NervesHubLink.Application do
           update_available: &Client.update_available/1
         }
 
-        downloader_config = %{
-          cache_firmware_to_disk: config.cache_firmware_to_disk,
-          cache_firmware_dir: config.cache_firmware_dir
-        }
-
         [
           {DynamicSupervisor, name: ExtensionsSupervisor},
           Extensions,
-          {UpdateManager, {fwup_config, downloader_config}},
+          {UpdateManager, {fwup_config, config.updater}},
           {ArchiveManager, config},
           {Socket, config}
         ]

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -36,6 +36,8 @@ defmodule NervesHubLink.Configurator do
     """
 
     defstruct archive_public_keys: [],
+              cache_firmware_to_disk: false,
+              cache_firmware_dir: "/data/nerves_hub_link/firmware",
               compress: true,
               connect: true,
               connect_wait_for_network: true,
@@ -61,6 +63,8 @@ defmodule NervesHubLink.Configurator do
 
     @type t() :: %__MODULE__{
             archive_public_keys: [binary()],
+            cache_firmware_to_disk: false,
+            cache_firmware_dir: String.t(),
             compress: boolean(),
             connect: boolean(),
             connect_wait_for_network: boolean(),

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -24,6 +24,7 @@ defmodule NervesHubLink.Configurator do
   alias __MODULE__.Config
   alias Nerves.Runtime.KV
   alias NervesHubLink.Backoff
+  alias NervesHubLink.UpdateManager.StreamingUpdater
 
   require Logger
 
@@ -36,8 +37,6 @@ defmodule NervesHubLink.Configurator do
     """
 
     defstruct archive_public_keys: [],
-              cache_firmware_to_disk: false,
-              cache_firmware_dir: "/data/nerves_hub_link/firmware",
               compress: true,
               connect: true,
               connect_wait_for_network: true,
@@ -59,12 +58,11 @@ defmodule NervesHubLink.Configurator do
               shared_secret: [],
               sni: nil,
               socket: [],
-              ssl: []
+              ssl: [],
+              updater: StreamingUpdater
 
     @type t() :: %__MODULE__{
             archive_public_keys: [binary()],
-            cache_firmware_to_disk: false,
-            cache_firmware_dir: String.t(),
             compress: boolean(),
             connect: boolean(),
             connect_wait_for_network: boolean(),
@@ -86,7 +84,8 @@ defmodule NervesHubLink.Configurator do
             shared_secret: [product_key: String.t(), product_secret: String.t()],
             sni: String.t(),
             socket: any(),
-            ssl: [:ssl.tls_client_option()]
+            ssl: [:ssl.tls_client_option()],
+            updater: NervesHubLink.UpdateManager.Updater.t()
           }
   end
 

--- a/lib/nerves_hub_link/downloader.ex
+++ b/lib/nerves_hub_link/downloader.ex
@@ -43,6 +43,7 @@ defmodule NervesHubLink.Downloader do
             conn: nil,
             request_ref: nil,
             status: nil,
+            completed: false,
             response_headers: [],
             content_length: 0,
             downloaded_length: 0,
@@ -50,11 +51,13 @@ defmodule NervesHubLink.Downloader do
             handler_fun: nil,
             retry_args: nil,
             max_timeout: nil,
+            resume_from_bytes: nil,
             retry_timeout: nil,
             worst_case_timeout: nil,
             worst_case_timeout_remaining_ms: nil
 
-  @type handler_event :: {:data, binary()} | {:error, any()} | :complete
+  @type handler_event ::
+          {:data, data :: binary(), percent_complete :: float()} | {:error, any()} | :complete
   @type event_handler_fun :: (handler_event -> any())
   @type retry_args :: RetryConfig.t()
 
@@ -66,9 +69,11 @@ defmodule NervesHubLink.Downloader do
           conn: nil | Mint.HTTP.t(),
           request_ref: nil | reference(),
           status: nil | Mint.Types.status(),
+          completed: boolean(),
           response_headers: Mint.Types.headers(),
           content_length: non_neg_integer(),
           downloaded_length: non_neg_integer(),
+          resume_from_bytes: nil | non_neg_integer(),
           retry_number: non_neg_integer(),
           handler_fun: event_handler_fun,
           retry_args: retry_args(),
@@ -93,6 +98,9 @@ defmodule NervesHubLink.Downloader do
   # todo, this should be `t`, but with retry_timeout
   @type resume_rescheduled :: t()
 
+  @type option :: {:resume_from_bytes, integer()} | {:retry_config, RetryConfig.t()}
+  @type options :: [option()]
+
   @doc """
   Begins downloading a file at `url` handled by `fun`.
 
@@ -100,7 +108,7 @@ defmodule NervesHubLink.Downloader do
 
         iex> pid = self()
         #PID<0.110.0>
-        iex> fun = fn {:data, data} -> File.write("index.html", data)
+        iex> fun = fn {:data, data, _percent} -> File.write("index.html", data)
         ...> {:error, error} -> IO.puts("error streaming file: \#{inspect(error)}")
         ...> :complete -> send pid, :complete
         ...> end
@@ -110,34 +118,34 @@ defmodule NervesHubLink.Downloader do
         iex> flush()
         :complete
   """
-  @spec start_download(String.t() | URI.t(), event_handler_fun()) :: GenServer.on_start()
-  def start_download(url, fun) when is_function(fun, 1) do
-    retry_config =
-      Application.get_env(:nerves_hub_link, :retry_config, [])
-      |> RetryConfig.validate()
-
-    GenServer.start_link(__MODULE__, [URI.parse(url), fun, retry_config])
-  end
-
-  @spec start_download(String.t() | URI.t(), event_handler_fun(), RetryConfig.t()) ::
+  @spec start_download(String.t() | URI.t(), event_handler_fun(), [option()]) ::
           GenServer.on_start()
-  def start_download(url, fun, %RetryConfig{} = retry_args) when is_function(fun, 1) do
-    GenServer.start_link(__MODULE__, [URI.parse(url), fun, retry_args])
+  def start_download(url, fun, opts \\ [])
+      when is_function(fun, 1) do
+    retry_config =
+      opts[:retry_config] ||
+        Application.get_env(:nerves_hub_link, :retry_config, []) |> RetryConfig.validate()
+
+    opts = Keyword.put(opts, :retry_config, retry_config)
+
+    GenServer.start_link(__MODULE__, [URI.parse(url), fun, opts])
   end
 
   @impl GenServer
-  def init([%URI{} = uri, fun, %RetryConfig{} = retry_args]) do
-    timer = Process.send_after(self(), :max_timeout, retry_args.max_timeout)
+  def init([%URI{} = uri, fun, opts]) do
+    timer = Process.send_after(self(), :max_timeout, opts[:retry_config].max_timeout)
 
     state =
       reset(%Downloader{
         handler_fun: fun,
-        retry_args: retry_args,
+        retry_args: opts[:retry_config],
         max_timeout: timer,
-        uri: uri
+        uri: uri,
+        resume_from_bytes: opts[:resume_from_bytes]
       })
 
     send(self(), :resume)
+
     {:ok, state}
   end
 
@@ -158,6 +166,7 @@ defmodule NervesHubLink.Downloader do
   # milliseconds have occurred. It indicates that many milliseconds have elapsed since
   # the last "chunk" from the HTTP server
   def handle_info(:timeout, %Downloader{handler_fun: handler} = state) do
+    {:ok, _} = Mint.HTTP.close(state.conn)
     _ = handler.({:error, :idle_timeout})
     state = reschedule_resume(state)
     {:noreply, state}
@@ -192,6 +201,7 @@ defmodule NervesHubLink.Downloader do
         handle_responses(responses, %{state | conn: conn})
 
       {:error, conn, error, responses} ->
+        {:ok, _} = Mint.HTTP.close(state.conn)
         _ = handler.({:error, error})
         handle_responses(responses, reschedule_resume(%{state | conn: conn}))
 
@@ -248,11 +258,8 @@ defmodule NervesHubLink.Downloader do
     end
   end
 
-  defp handle_responses(
-         [],
-         %Downloader{downloaded_length: downloaded, content_length: downloaded} = state
-       )
-       when downloaded != 0 do
+  defp handle_responses([], %Downloader{completed: true} = state) do
+    {:ok, _} = Mint.HTTP.close(state.conn)
     _ = state.handler_fun.(:complete)
     {:stop, :normal, state}
   end
@@ -282,6 +289,7 @@ defmodule NervesHubLink.Downloader do
       )
       when status >= 400 do
     # kind of a hack to make the error type uniform
+    {:ok, _} = Mint.HTTP.close(state.conn)
     state.handler_fun.({:error, %Mint.HTTPError{reason: {:http_error, status}}})
     %Downloader{state | status: status}
   end
@@ -348,14 +356,25 @@ defmodule NervesHubLink.Downloader do
 
   def handle_response(
         {:data, request_ref, data},
-        %Downloader{request_ref: request_ref, downloaded_length: downloaded} = state
+        %Downloader{
+          request_ref: request_ref,
+          resume_from_bytes: resume_from_bytes,
+          downloaded_length: downloaded,
+          content_length: content_length
+        } = state
       ) do
-    _ = state.handler_fun.({:data, data})
-    %Downloader{state | downloaded_length: downloaded + byte_size(data)}
+    downloaded_length = downloaded + byte_size(data)
+
+    resume_from_bytes = resume_from_bytes || 0
+    percent = (downloaded + resume_from_bytes) / (content_length + resume_from_bytes) * 100
+
+    _ = state.handler_fun.({:data, data, Float.round(percent, 2)})
+
+    %Downloader{state | downloaded_length: downloaded_length}
   end
 
   def handle_response({:done, request_ref}, %Downloader{request_ref: request_ref} = state) do
-    state
+    %{state | completed: true}
   end
 
   # ignore other messages when redirecting
@@ -395,6 +414,11 @@ defmodule NervesHubLink.Downloader do
       Logger.info("[NervesHubLink] Resuming download attempt number #{state.retry_number} #{uri}")
     end
 
+    _ =
+      if not is_nil(state.conn) and state.conn.state != :closed do
+        Mint.HTTP.close(state.conn)
+      end
+
     with {:ok, conn} <- Mint.HTTP.connect(String.to_existing_atom(scheme), host, port),
          {:ok, conn, request_ref} <- Mint.HTTP.request(conn, "GET", path, request_headers, nil) do
       {:ok,
@@ -429,11 +453,17 @@ defmodule NervesHubLink.Downloader do
   @spec add_range_header(Mint.Types.headers(), t()) :: Mint.Types.headers()
   defp add_range_header(headers, state)
 
+  defp add_range_header(headers, %Downloader{resume_from_bytes: r, content_length: 0})
+       when not is_nil(r) and r > 0 do
+    [{"Range", "bytes=#{r}-"} | headers]
+  end
+
   defp add_range_header(headers, %Downloader{content_length: 0}), do: headers
 
   defp add_range_header(headers, %Downloader{downloaded_length: r, content_length: total})
-       when total > 0,
-       do: [{"Range", "bytes=#{r}-#{total}"} | headers]
+       when total > 0 do
+    [{"Range", "bytes=#{r}-#{total}"} | headers]
+  end
 
   @spec add_retry_number_header(Mint.Types.headers(), t()) :: Mint.Types.headers()
   defp add_retry_number_header(headers, %Downloader{retry_number: retry_number}),

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -17,20 +17,17 @@ defmodule NervesHubLink.UpdateManager do
   use GenServer
 
   alias NervesHubLink.Alarms
-  alias NervesHubLink.Downloader
   alias NervesHubLink.FwupConfig
   alias NervesHubLink.Message.UpdateInfo
   alias NervesHubLink.UpdateManager
+  alias NervesHubLink.UpdateManager.Updater
 
   require Logger
 
   @type status ::
           :idle
-          | {:fwup_error, String.t()}
           | :update_rescheduled
-          | {:downloading, integer()}
-          | {:updating, integer()}
-          | :applying
+          | :updating
 
   defmodule State do
     @moduledoc false
@@ -38,24 +35,20 @@ defmodule NervesHubLink.UpdateManager do
     @type t :: %__MODULE__{
             status: UpdateManager.status(),
             update_reschedule_timer: nil | :timer.tref(),
-            download: nil | GenServer.server(),
-            downloader_config: map(),
-            cached_download_pid: nil | pid(),
-            cached_download_path: nil | String.t(),
+            updater: nil | GenServer.server(),
             fwup: nil | GenServer.server(),
             fwup_config: FwupConfig.t(),
-            update_info: nil | UpdateInfo.t()
+            update_info: nil | UpdateInfo.t(),
+            updater_pid: nil | pid()
           }
 
-    defstruct status: :idle,
-              update_reschedule_timer: nil,
-              fwup: nil,
-              download: nil,
-              downloader_config: nil,
-              cached_download_pid: nil,
-              cached_download_path: nil,
+    defstruct fwup: nil,
               fwup_config: nil,
-              update_info: nil
+              status: :idle,
+              update_info: nil,
+              update_reschedule_timer: nil,
+              updater: nil,
+              updater_pid: nil
   end
 
   @doc """
@@ -84,50 +77,39 @@ defmodule NervesHubLink.UpdateManager do
     GenServer.call(manager, :currently_downloading_uuid)
   end
 
-  # Private API for reporting download progress. This wraps a GenServer.call so
-  # that it can apply back pressure to the downloader if applying the update is
-  # slow.
-  defp report_stream(manager, message) do
-    # 60 seconds is arbitrary, but currently matches the `fwup` library's
-    # default timeout. Having fwup take longer than 5 seconds to perform a
-    # write operation seems remote except for perhaps an exceptionally well
-    # compressed delta update. The consequences of crashing here because fwup
-    # doesn't have enough time are severe, though, since they prevent an
-    # update.
-    GenServer.call(manager, {:stream, message}, 60_000)
-  end
+  @doc """
+  Change `Updater` used for the next firmware update.
 
-  defp report_download(manager, message, fwup_public_keys) do
-    # 60 seconds is arbitrary, but currently matches the `fwup` library's
-    # default timeout. Having fwup take longer than 5 seconds to perform a
-    # write operation seems remote except for perhaps an exceptionally well
-    # compressed delta update. The consequences of crashing here because fwup
-    # doesn't have enough time are severe, though, since they prevent an
-    # update.
-    GenServer.call(manager, {:download, message, fwup_public_keys}, 60_000)
+  `Updater`s orchestrate firmware downloads and installation.
+  """
+  @spec change_updater(GenServer.server(), Updater.t()) :: :ok
+  def change_updater(manager \\ __MODULE__, updater) do
+    GenServer.cast(manager, {:change_updater, updater})
   end
 
   @doc false
-  @spec child_spec({FwupConfig.t(), map()}) :: Supervisor.child_spec()
-  def child_spec({%FwupConfig{} = _fwup_config, %{}} = args) do
+  @spec child_spec({FwupConfig.t(), Updater.t()}) :: Supervisor.child_spec()
+  def child_spec({%FwupConfig{} = fwup_config, updater}) do
     %{
-      start: {__MODULE__, :start_link, [args, [name: __MODULE__]]},
+      start: {__MODULE__, :start_link, [{fwup_config, updater}, [name: __MODULE__]]},
       id: __MODULE__
     }
   end
 
   @doc false
-  @spec start_link({FwupConfig.t(), map()}, GenServer.options()) :: GenServer.on_start()
-  def start_link({%FwupConfig{} = _fwup_config, %{}} = args, opts \\ []) do
-    GenServer.start_link(__MODULE__, args, opts)
+  @spec start_link({FwupConfig.t(), Updater.t()}, GenServer.options()) :: GenServer.on_start()
+  def start_link({%FwupConfig{} = fwup_config, updater}, opts \\ []) do
+    GenServer.start_link(__MODULE__, [fwup_config, updater], opts)
   end
 
   @impl GenServer
-  def init({%FwupConfig{} = fwup_config, downloader_config}) do
-    Alarms.clear_alarm(NervesHubLink.UpdateInProgress)
+  def init([%FwupConfig{} = fwup_config, updater]) do
     fwup_config = FwupConfig.validate!(fwup_config)
 
-    {:ok, %State{fwup_config: fwup_config, downloader_config: downloader_config}}
+    # listen for updaters dying
+    Process.flag(:trap_exit, true)
+
+    {:ok, %State{fwup_config: fwup_config, updater: updater}}
   end
 
   @impl GenServer
@@ -152,61 +134,11 @@ defmodule NervesHubLink.UpdateManager do
     {:reply, state.status, state}
   end
 
-  # messages from Downloader
-  def handle_call({:stream, :complete}, _from, state) do
-    Logger.info("[NervesHubLink] Firmware Download complete")
-    {:reply, :ok, %State{state | download: nil}}
-  end
-
-  def handle_call({:stream, {:error, reason}}, _from, state) do
-    Logger.error("[NervesHubLink] Nonfatal HTTP download error: #{inspect(reason)}")
-    {:reply, :ok, state}
-  end
-
-  # Data from the downloader is sent to fwup
-  def handle_call({:stream, {:data, data, _percent}}, _from, state) do
-    _ = Fwup.Stream.send_chunk(state.fwup, data)
-    {:reply, :ok, state}
-  end
-
-  # messages from Downloader
-  def handle_call({:download, :complete, fwup_public_keys}, _from, state) do
-    :ok = File.close(state.cached_download_pid)
-
-    firmware_file_path = String.trim_trailing(state.cached_download_path, ".partial")
-    :ok = File.rename(state.cached_download_path, firmware_file_path)
-
-    stat = File.stat(firmware_file_path)
-
-    Logger.info("[NervesHubLink] Firmware download complete (#{stat.size} bytes)")
-
-    send(self(), {:send_cached_firmware_to_fwup, firmware_file_path, fwup_public_keys})
-
-    {:reply, :ok,
-     %State{
-       state
-       | download: nil,
-         cached_download_pid: nil,
-         cached_download_path: firmware_file_path
-     }}
-  end
-
-  def handle_call({:download, {:error, reason}}, _from, state) do
-    :ok = File.close(state.cached_download_pid)
-    Logger.error("[NervesHubLink] Nonfatal HTTP download error: #{inspect(reason)}")
-    {:reply, :ok, state}
-  end
-
-  # Data from the downloader is sent to fwup
-  def handle_call({:download, {:data, data, percent}}, _from, state) do
-    IO.binwrite(state.cached_download_pid, data)
-
-    NervesHubLink.send_update_progress(round(percent))
-
-    {:reply, :ok, %State{state | status: {:downloading, percent}}}
-  end
-
   @impl GenServer
+  def handle_info({:change_updater, updater}, state) do
+    {:noreply, %State{state | updater: updater}}
+  end
+
   def handle_info({:update_reschedule, response, fwup_public_keys}, state) do
     {:noreply,
      maybe_update_firmware(response, fwup_public_keys, %State{
@@ -215,49 +147,41 @@ defmodule NervesHubLink.UpdateManager do
      })}
   end
 
-  # messages from FWUP
-  def handle_info({:fwup, message}, state) do
-    _ = state.fwup_config.handle_fwup_message.(message)
-
-    case message do
-      {:ok, 0, _message} ->
-        Logger.info("[NervesHubLink] FWUP Finished")
-        Alarms.clear_alarm(NervesHubLink.UpdateInProgress)
-        {:noreply, %State{state | fwup: nil, update_info: nil, status: :idle}}
-
-      {:progress, percent} ->
-        {:noreply, %State{state | status: {:updating, percent}}}
-
-      {:error, _, message} ->
-        Alarms.clear_alarm(NervesHubLink.UpdateInProgress)
-        {:noreply, %State{state | status: {:fwup_error, message}}}
-
-      _ ->
-        {:noreply, state}
-    end
+  def handle_info(
+        {:EXIT, updater_pid, {:shutdown, :update_complete}},
+        %State{updater_pid: updater_pid} = state
+      ) do
+    Logger.info("Update completed successfully")
+    {:noreply, %State{state | status: :idle, updater_pid: nil, update_info: nil}}
   end
 
-  def handle_info({:send_cached_firmware_to_fwup, firmware_path, fwup_public_keys}, state) do
-    public_keys =
-      Enum.reduce(fwup_public_keys, [], fn public_key, args ->
-        args ++ ["--public-key", public_key]
-      end)
+  def handle_info(
+        {:EXIT, updater_pid, {:shutdown, {:error, reason}}},
+        %State{updater_pid: updater_pid} = state
+      ) do
+    Logger.info("Update failed with reason : #{inspect(reason)}")
+    {:noreply, %State{state | status: :idle, updater_pid: nil, update_info: nil}}
+  end
 
-    Logger.info("[NervesHubLink] Requesting FWUP apply the firmware update : #{firmware_path}")
+  def handle_info(
+        {:EXIT, updater_pid, {:shutdown, {:fwup_error, reason}}},
+        %State{updater_pid: updater_pid} = state
+      ) do
+    Logger.info("Update failed with reason : #{inspect(reason)}")
+    {:noreply, %State{state | status: :idle, updater_pid: nil, update_info: nil}}
+  end
 
-    {:ok, fwup} =
-      Fwup.apply(state.fwup_config.fwup_devpath, state.fwup_config.fwup_task, firmware_path,
-        fwup_env: public_keys
-      )
+  def handle_info({:EXIT, _, _} = msg, state) do
+    Logger.info("Unexpected :EXIT : pid #{inspect(msg)}, state #{inspect(state)}")
 
-    {:noreply, %State{state | status: :applying, fwup: fwup}}
+    {:noreply, %State{state | status: :idle, updater_pid: nil, update_info: nil}}
   end
 
   @spec maybe_update_firmware(UpdateInfo.t(), [binary()], State.t()) :: State.t()
   defp maybe_update_firmware(
          %UpdateInfo{} = _update_info,
          _fwup_public_keys,
-         %State{status: {:updating, _percent}} = state
+         %State{status: :updating} = state
        ) do
     # Received an update message from NervesHub, but we're already in progress.
     # It could be because the deployment/device was edited making a duplicate
@@ -280,11 +204,12 @@ defmodule NervesHubLink.UpdateManager do
     # note: update_available is a behaviour function
     case state.fwup_config.update_available.(update_info) do
       :apply ->
-        if state.downloader_config[:cache_firmware_to_disk] do
-          start_cached_fwup_stream(update_info, fwup_public_keys, state)
-        else
-          start_fwup_stream(update_info, fwup_public_keys, state)
-        end
+        {:ok, updater_pid} =
+          state.updater.start_update(update_info, state.fwup_config, fwup_public_keys)
+
+        Alarms.set_alarm({NervesHubLink.UpdateInProgress, []})
+
+        %State{state | status: :updating, updater_pid: updater_pid, update_info: update_info}
 
       :ignore ->
         state
@@ -306,79 +231,5 @@ defmodule NervesHubLink.UpdateManager do
     _ = Process.cancel_timer(timer)
 
     %{state | update_reschedule_timer: nil}
-  end
-
-  @spec start_fwup_stream(UpdateInfo.t(), [binary()], State.t()) :: State.t()
-  defp start_fwup_stream(%UpdateInfo{} = update_info, fwup_public_keys, state) do
-    pid = self()
-    fun = &report_stream(pid, &1)
-    {:ok, download} = Downloader.start_download(update_info.firmware_url, fun)
-
-    {:ok, fwup} =
-      Fwup.stream(pid, fwup_args(state.fwup_config, fwup_public_keys),
-        fwup_env: state.fwup_config.fwup_env
-      )
-
-    Logger.info("[NervesHubLink] Downloading firmware: #{update_info.firmware_url}")
-    Alarms.set_alarm({NervesHubLink.UpdateInProgress, []})
-
-    %State{
-      state
-      | status: {:updating, 0},
-        download: download,
-        fwup: fwup,
-        update_info: update_info
-    }
-  end
-
-  defp start_cached_fwup_stream(%UpdateInfo{} = update_info, fwup_public_keys, state) do
-    path_parts = String.split(update_info.firmware_url, "/")
-    file_name_with_query = List.last(path_parts)
-    file_name = String.replace(file_name_with_query, ~r/\?.*/, "")
-
-    firmware_dir = state.downloader_config.cache_firmware_dir
-
-    full_path = Path.join(firmware_dir, "#{file_name}.partial")
-
-    start_from =
-      case File.stat(full_path) do
-        {:ok, stat} ->
-          Logger.info("[NervesHubLink] Partial firmware download exists (#{stat.size} bytes)")
-          stat.size
-
-        {:error, _} ->
-          _ = File.rmdir(firmware_dir)
-          :ok = File.mkdir_p(firmware_dir)
-          0
-      end
-
-    file_pid = File.open!("#{file_name}.partial", [:read, :write, :append, :binary])
-
-    pid = self()
-    fun = &report_download(pid, &1, fwup_public_keys)
-
-    {:ok, download} =
-      Downloader.start_download(update_info.firmware_url, fun, resume_from_bytes: start_from)
-
-    Logger.info("[NervesHubLink] Downloading firmware: #{update_info.firmware_url}")
-    Alarms.set_alarm({NervesHubLink.UpdateInProgress, []})
-
-    %State{
-      state
-      | status: {:downloading, 0},
-        download: download,
-        update_info: update_info,
-        cached_download_pid: file_pid,
-        cached_download_path: full_path
-    }
-  end
-
-  @spec fwup_args(FwupConfig.t(), list(String.t())) :: [String.t()]
-  defp fwup_args(%FwupConfig{} = config, fwup_public_keys) do
-    args = ["--apply", "--no-unmount", "-d", config.fwup_devpath, "--task", config.fwup_task]
-
-    Enum.reduce(fwup_public_keys, args, fn public_key, args ->
-      args ++ ["--public-key", public_key]
-    end)
   end
 end

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -133,10 +133,11 @@ defmodule NervesHubLink.UpdateManager do
   end
 
   @impl GenServer
-  def handle_info({:change_updater, updater}, state) do
+  def handle_cast({:change_updater, updater}, state) do
     {:noreply, %State{state | updater: updater}}
   end
 
+  @impl GenServer
   def handle_info({:update_reschedule, response, fwup_public_keys}, state) do
     {:noreply,
      maybe_update_firmware(response, fwup_public_keys, %State{

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -33,17 +33,15 @@ defmodule NervesHubLink.UpdateManager do
     @moduledoc false
 
     @type t :: %__MODULE__{
-            status: UpdateManager.status(),
-            update_reschedule_timer: nil | :timer.tref(),
-            updater: nil | GenServer.server(),
-            fwup: nil | GenServer.server(),
             fwup_config: FwupConfig.t(),
+            status: UpdateManager.status(),
             update_info: nil | UpdateInfo.t(),
+            update_reschedule_timer: nil | :timer.tref(),
+            updater: nil | Updater.t(),
             updater_pid: nil | pid()
           }
 
-    defstruct fwup: nil,
-              fwup_config: nil,
+    defstruct fwup_config: nil,
               status: :idle,
               update_info: nil,
               update_reschedule_timer: nil,

--- a/lib/nerves_hub_link/update_manager/caching_updater.ex
+++ b/lib/nerves_hub_link/update_manager/caching_updater.ex
@@ -1,0 +1,147 @@
+defmodule NervesHubLink.UpdateManager.CachingUpdater do
+  use NervesHubLink.UpdateManager.Updater
+
+  alias NervesHubLink.Downloader
+  alias NervesHubLink.FwupConfig
+  alias NervesHubLink.UpdateInfo
+
+  require Logger
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def start(state) do
+    firmware_url = URI.to_string(state.update_info.firmware_url)
+
+    path_parts = String.split(firmware_url, "/")
+    file_name_with_query = List.last(path_parts)
+    file_name = String.replace(file_name_with_query, ~r/\?.*/, "")
+
+    firmware_dir = settings()[:cache_dir]
+
+    full_path = Path.join(firmware_dir, "#{file_name}.partial")
+
+    clean_caching_directory(firmware_dir, "#{file_name}.partial")
+
+    start_from =
+      case File.stat(full_path) do
+        {:ok, stat} ->
+          Logger.info("[#{log_prefix()}] Partial firmware download exists (#{stat.size} bytes)")
+          stat.size
+
+        {:error, _} ->
+          Logger.info("[#{log_prefix()}] No partial firmware download found")
+          0
+      end
+
+    file_pid = File.open!(full_path, [:read, :write, :append, :binary])
+
+    {:ok, download} =
+      Downloader.start_download(firmware_url, state.reporting_download_fun,
+        resume_from_bytes: start_from
+      )
+
+    Logger.info(
+      "[#{log_prefix()}] Downloading firmware: #{String.replace(firmware_url, ~r/\?.*/, "?...")}"
+    )
+
+    Alarms.set_alarm({NervesHubLink.UpdateInProgress, []})
+
+    {:ok,
+     Map.merge(
+       state,
+       %{
+         status: {:downloading, 0},
+         download: download,
+         cached_download_pid: file_pid,
+         cached_download_path: full_path
+       }
+     )}
+  end
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def handle_downloader_message(:complete, state) do
+    :ok = File.close(state.cached_download_pid)
+
+    firmware_file_path = String.trim_trailing(state.cached_download_path, ".partial")
+    :ok = File.rename(state.cached_download_path, firmware_file_path)
+
+    {:ok, stat} = File.stat(firmware_file_path)
+
+    Logger.info("[NervesHubLink] Firmware download complete (#{stat.size} bytes)")
+    Logger.info("[NervesHubLink] Requesting FWUP apply the firmware update")
+
+    {:ok, fwup} =
+      Fwup.stream(
+        self(),
+        fwup_args(state.fwup_config, firmware_file_path, state.fwup_public_keys),
+        fwup_env: state.fwup_config.fwup_env
+      )
+
+    {:ok,
+     Map.merge(state, %{
+       cached_download_pid: nil,
+       cached_download_path: firmware_file_path,
+       fwup: fwup,
+       status: {:updating, 0}
+     })}
+  end
+
+  def handle_downloader_message({:error, reason}, state) do
+    :ok = File.close(state.cached_download_pid)
+    Logger.error("[#{log_prefix()}] Nonfatal HTTP download error: #{inspect(reason)}")
+    {:ok, state}
+  end
+
+  # Data from the downloader is sent to fwup
+  def handle_downloader_message({:data, data, percent}, state) do
+    IO.binwrite(state.cached_download_pid, data)
+
+    NervesHubLink.send_update_progress(round(percent))
+
+    {:ok, state}
+  end
+
+  defp clean_caching_directory(caching_dir, file_name) do
+    case File.ls(caching_dir) do
+      {:ok, file_list} ->
+        file_list = Enum.reject(file_list, fn name -> name == file_name end)
+
+        if Enum.any?(file_list) do
+          Logger.info(
+            "[#{log_prefix()}] Removing #{Enum.count(file_list)} previous firmware files from the cache directory"
+          )
+
+          Enum.each(file_list, fn file -> File.rm(Path.join(caching_dir, file)) end)
+        end
+
+        :ok
+
+      _ ->
+        :ok = File.mkdir_p(caching_dir)
+    end
+  end
+
+  defp fwup_args(%FwupConfig{} = config, firmware_path, fwup_public_keys) do
+    args = [
+      "--apply",
+      "--no-unmount",
+      "-d",
+      config.fwup_devpath,
+      "--task",
+      config.fwup_task,
+      "-i",
+      firmware_path
+    ]
+
+    Enum.reduce(fwup_public_keys, args, fn public_key, args ->
+      args ++ ["--public-key", public_key]
+    end)
+  end
+
+  def log_prefix(), do: "NervesHubLink:CachingUpdater"
+
+  defp settings() do
+    Application.get_env(:nerves_hub_link, CachingUpdater,
+      cache_dir: "/data/nerves_hub_link/firmware"
+    )
+  end
+end

--- a/lib/nerves_hub_link/update_manager/caching_updater.ex
+++ b/lib/nerves_hub_link/update_manager/caching_updater.ex
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 defmodule NervesHubLink.UpdateManager.CachingUpdater do
   @moduledoc false
   use NervesHubLink.UpdateManager.Updater

--- a/lib/nerves_hub_link/update_manager/caching_updater.ex
+++ b/lib/nerves_hub_link/update_manager/caching_updater.ex
@@ -1,4 +1,5 @@
 defmodule NervesHubLink.UpdateManager.CachingUpdater do
+  @moduledoc false
   use NervesHubLink.UpdateManager.Updater
 
   alias NervesHubLink.Downloader
@@ -110,7 +111,7 @@ defmodule NervesHubLink.UpdateManager.CachingUpdater do
             "[#{log_prefix()}] Removing #{Enum.count(file_list)} previous firmware files from the cache directory"
           )
 
-          Enum.each(file_list, fn file -> File.rm(Path.join(caching_dir, file)) end)
+          Enum.each(file_list, &File.rm(Path.join(caching_dir, &1)))
         end
 
         :ok
@@ -137,6 +138,7 @@ defmodule NervesHubLink.UpdateManager.CachingUpdater do
     end)
   end
 
+  @impl NervesHubLink.UpdateManager.Updater
   def log_prefix(), do: "NervesHubLink:CachingUpdater"
 
   defp settings() do

--- a/lib/nerves_hub_link/update_manager/streaming_updater.ex
+++ b/lib/nerves_hub_link/update_manager/streaming_updater.ex
@@ -1,0 +1,62 @@
+defmodule NervesHubLink.UpdateManager.StreamingUpdater do
+  use NervesHubLink.UpdateManager.Updater
+
+  alias NervesHubLink.Downloader
+  alias NervesHubLink.FwupConfig
+  alias NervesHubLink.UpdateInfo
+
+  require Logger
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def start(state) do
+    {:ok, download} =
+      Downloader.start_download(state.update_info.firmware_url, state.reporting_download_fun)
+
+    {:ok, fwup} =
+      Fwup.stream(self(), fwup_args(state.fwup_config, state.fwup_public_keys),
+        fwup_env: state.fwup_config.fwup_env
+      )
+
+    url_without_query =
+      state.update_info.firmware_url
+      |> URI.to_string()
+      |> String.replace(~r/\?.*/, "?...")
+
+    Logger.info("[#{log_prefix()}] Downloading firmware: #{url_without_query}")
+
+    {:ok,
+     Map.merge(state, %{
+       status: {:updating, 0},
+       download: download,
+       fwup: fwup
+     })}
+  end
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def handle_downloader_message(:complete, state) do
+    Logger.info("[#{log_prefix()}] Firmware download complete")
+    {:ok, state}
+  end
+
+  def handle_downloader_message({:error, reason}, state) do
+    Logger.error("[#{log_prefix()}] Nonfatal HTTP download error: #{inspect(reason)}")
+    {:ok, state}
+  end
+
+  # Data from the downloader is sent to fwup
+  def handle_downloader_message({:data, data, _percent}, state) do
+    _ = Fwup.Stream.send_chunk(state.fwup, data)
+    {:ok, state}
+  end
+
+  @spec fwup_args(FwupConfig.t(), list(String.t())) :: [String.t()]
+  defp fwup_args(%FwupConfig{} = config, fwup_public_keys) do
+    args = ["--apply", "--no-unmount", "-d", config.fwup_devpath, "--task", config.fwup_task]
+
+    Enum.reduce(fwup_public_keys, args, fn public_key, args ->
+      args ++ ["--public-key", public_key]
+    end)
+  end
+
+  def log_prefix(), do: "NervesHubLink:StreamingUpdater"
+end

--- a/lib/nerves_hub_link/update_manager/streaming_updater.ex
+++ b/lib/nerves_hub_link/update_manager/streaming_updater.ex
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 defmodule NervesHubLink.UpdateManager.StreamingUpdater do
   @moduledoc false
   use NervesHubLink.UpdateManager.Updater

--- a/lib/nerves_hub_link/update_manager/streaming_updater.ex
+++ b/lib/nerves_hub_link/update_manager/streaming_updater.ex
@@ -1,4 +1,5 @@
 defmodule NervesHubLink.UpdateManager.StreamingUpdater do
+  @moduledoc false
   use NervesHubLink.UpdateManager.Updater
 
   alias NervesHubLink.Downloader
@@ -58,5 +59,6 @@ defmodule NervesHubLink.UpdateManager.StreamingUpdater do
     end)
   end
 
+  @impl NervesHubLink.UpdateManager.Updater
   def log_prefix(), do: "NervesHubLink:StreamingUpdater"
 end

--- a/lib/nerves_hub_link/update_manager/updater.ex
+++ b/lib/nerves_hub_link/update_manager/updater.ex
@@ -1,0 +1,132 @@
+defmodule NervesHubLink.UpdateManager.Updater do
+  @doc """
+  `Updater`s orchestrate the complete workflow of downloading and installing/applying
+  firmware updates.
+  """
+
+  @type t :: __MODULE__
+
+  @type standard_response ::
+          {:noreply, new_state :: term()}
+          | {:noreply, new_state :: term(),
+             timeout() | :hibernate | {:continue, continue_arg :: term()}}
+          | {:stop, reason :: term(), new_state :: term()}
+
+  @callback start(state :: term()) :: {:ok, new_state :: term()}
+  @callback handle_downloader_message(message :: term(), state :: term()) ::
+              {:ok, new_state :: term()} | {:stop, reason :: term(), new_state :: term()}
+  @callback handle_fwup_message(message :: term(), state :: term()) ::
+              {:ok, new_state :: term()} | {:stop, reason :: term(), new_state :: term()}
+
+  defmacro __using__(_opts) do
+    quote do
+      use GenServer
+
+      @behaviour NervesHubLink.UpdateManager.Updater
+
+      alias NervesHubLink.Alarms
+      alias NervesHubLink.FwupConfig
+      alias NervesHubLink.Message.UpdateInfo
+
+      require Logger
+
+      @spec start_update(
+              UpdateInfo.t(),
+              FwupConfig.t(),
+              fwup_public_keys :: []
+            ) ::
+              GenServer.on_start()
+      def start_update(update_info, fwup_config, fwup_public_keys) do
+        start_link(update_info, fwup_config, fwup_public_keys)
+      end
+
+      @spec start_link(
+              UpdateInfo.t(),
+              FwupConfig.t(),
+              fwup_public_keys :: [],
+              GenServer.options()
+            ) :: GenServer.on_start()
+      def start_link(update_info, fwup_config, fwup_public_keys, opts \\ []) do
+        GenServer.start_link(
+          __MODULE__,
+          [update_info, fwup_config, fwup_public_keys],
+          opts
+        )
+      end
+
+      def log_prefix(), do: "NervesHubLink:Updater"
+
+      @impl GenServer
+      def init([update_info, fwup_config, fwup_public_keys]) do
+        fwup_config = FwupConfig.validate!(fwup_config)
+
+        pid = self()
+
+        send(pid, :start)
+
+        {:ok,
+         %{
+           fwup_config: fwup_config,
+           fwup_public_keys: fwup_public_keys,
+           update_info: update_info,
+           reporting_download_fun: &report_download(pid, &1)
+         }}
+      end
+
+      @impl GenServer
+      def handle_info(:start, state) do
+        {:ok, state} = start(state)
+        Alarms.set_alarm({NervesHubLink.UpdateInProgress, []})
+        {:noreply, state}
+      end
+
+      def handle_info({:fwup, message}, state) do
+        case handle_fwup_message(message, state) do
+          {:ok, state} -> {:noreply, state}
+          {:stop, _reason, _state} = result -> result
+        end
+      end
+
+      @impl GenServer
+      def handle_call({:downloader, message}, _from, state) do
+        {:ok, state} = handle_downloader_message(message, state)
+        {:reply, :ok, state}
+      end
+
+      @impl NervesHubLink.UpdateManager.Updater
+      def handle_fwup_message(fwup_message, state) do
+        _ = state.fwup_config.handle_fwup_message.(fwup_message)
+
+        case fwup_message do
+          {:ok, 0, _message} ->
+            Logger.info("[#{log_prefix()}] Update Finished")
+            Alarms.clear_alarm(NervesHubLink.UpdateInProgress)
+            {:stop, {:shutdown, :update_complete}, state}
+
+          {:progress, percent} ->
+            {:ok, Map.put(state, :status, {:updating, percent})}
+
+          {:error, _, message} ->
+            Logger.warning("[#{log_prefix()}] Error applying update : #{inspect(message)}")
+            Alarms.clear_alarm(NervesHubLink.UpdateInProgress)
+            {:stop, {:shutdown, {:fwup_error, message}}, state}
+
+          _ ->
+            {:ok, state}
+        end
+      end
+
+      defp report_download(updater, message) do
+        # 60 seconds is arbitrary, but currently matches the `fwup` library's
+        # default timeout. Having fwup take longer than 5 seconds to perform a
+        # write operation seems remote except for perhaps an exceptionally well
+        # compressed delta update. The consequences of crashing here because fwup
+        # doesn't have enough time are severe, though, since they prevent an
+        # update.
+        GenServer.call(updater, {:downloader, message}, 60_000)
+      end
+
+      defoverridable init: 1, handle_fwup_message: 2, log_prefix: 0
+    end
+  end
+end

--- a/lib/nerves_hub_link/update_manager/updater.ex
+++ b/lib/nerves_hub_link/update_manager/updater.ex
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 defmodule NervesHubLink.UpdateManager.Updater do
   @moduledoc """
   `Updater`s orchestrate the complete workflow of downloading and installing/applying

--- a/lib/nerves_hub_link/update_manager/updater.ex
+++ b/lib/nerves_hub_link/update_manager/updater.ex
@@ -1,5 +1,5 @@
 defmodule NervesHubLink.UpdateManager.Updater do
-  @doc """
+  @moduledoc """
   `Updater`s orchestrate the complete workflow of downloading and installing/applying
   firmware updates.
   """
@@ -17,6 +17,7 @@ defmodule NervesHubLink.UpdateManager.Updater do
               {:ok, new_state :: term()} | {:stop, reason :: term(), new_state :: term()}
   @callback handle_fwup_message(message :: term(), state :: term()) ::
               {:ok, new_state :: term()} | {:stop, reason :: term(), new_state :: term()}
+  @callback log_prefix() :: String.t()
 
   defmacro __using__(_opts) do
     quote do
@@ -53,8 +54,6 @@ defmodule NervesHubLink.UpdateManager.Updater do
           opts
         )
       end
-
-      def log_prefix(), do: "NervesHubLink:Updater"
 
       @impl GenServer
       def init([update_info, fwup_config, fwup_public_keys]) do
@@ -115,6 +114,9 @@ defmodule NervesHubLink.UpdateManager.Updater do
             {:ok, state}
         end
       end
+
+      @impl NervesHubLink.UpdateManager.Updater
+      def log_prefix(), do: "NervesHubLink:Updater"
 
       defp report_download(updater, message) do
         # 60 seconds is arbitrary, but currently matches the `fwup` library's

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -32,7 +32,7 @@ defmodule NervesHubLink.UpdateManagerTest do
     test "apply", %{update_payload: update_payload, devpath: devpath} do
       fwup_config = %{default_config() | fwup_devpath: devpath}
 
-      {:ok, manager} = UpdateManager.start_link(fwup_config)
+      {:ok, manager} = UpdateManager.start_link({fwup_config, %{}})
       assert UpdateManager.apply_update(manager, update_payload, []) == {:updating, 0}
 
       assert_receive {:fwup, {:progress, 0}}
@@ -61,7 +61,7 @@ defmodule NervesHubLink.UpdateManagerTest do
           update_available: update_available_fun
       }
 
-      {:ok, manager} = UpdateManager.start_link(fwup_config)
+      {:ok, manager} = UpdateManager.start_link({fwup_config, %{}})
       assert UpdateManager.apply_update(manager, update_payload, []) == :update_rescheduled
       assert_received :rescheduled
       refute_received {:fwup, _}
@@ -83,7 +83,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       # If setting SUPER_SECRET in the environment doesn't happen, then test fails
       # due to fwup getting a bad aes key.
-      {:ok, manager} = UpdateManager.start_link(fwup_config)
+      {:ok, manager} = UpdateManager.start_link({fwup_config, %{}})
       assert UpdateManager.apply_update(manager, update_payload, []) == {:updating, 0}
 
       assert_receive {:fwup, {:progress, 0}}

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -22,25 +22,31 @@ defmodule NervesHubLink.UpdateManagerTest do
       File.rm(devpath)
 
       update_payload = %UpdateInfo{
-        firmware_url: "http://localhost:#{port}/test.fw",
+        firmware_url: URI.parse("http://localhost:#{port}/test.fw"),
         firmware_meta: %FirmwareMetadata{}
       }
 
-      {:ok, [plug: plug, update_payload: update_payload, devpath: "/tmp/fwup_output"]}
+      {:ok,
+       [
+         plug: plug,
+         update_payload: update_payload,
+         devpath: "/tmp/fwup_output",
+         updater: NervesHubLink.UpdateManager.StreamingUpdater
+       ]}
     end
 
-    test "apply", %{update_payload: update_payload, devpath: devpath} do
+    test "apply", %{update_payload: update_payload, devpath: devpath, updater: updater} do
       fwup_config = %{default_config() | fwup_devpath: devpath}
 
-      {:ok, manager} = UpdateManager.start_link({fwup_config, %{}})
-      assert UpdateManager.apply_update(manager, update_payload, []) == {:updating, 0}
+      {:ok, manager} = UpdateManager.start_link({fwup_config, updater})
+      assert UpdateManager.apply_update(manager, update_payload, []) == :updating
 
       assert_receive {:fwup, {:progress, 0}}
       assert_receive {:fwup, {:progress, 100}}
       assert_receive {:fwup, {:ok, 0, ""}}
     end
 
-    test "reschedule", %{update_payload: update_payload, devpath: devpath} do
+    test "reschedule", %{update_payload: update_payload, devpath: devpath, updater: updater} do
       test_pid = self()
 
       update_available_fun = fn _ ->
@@ -61,7 +67,7 @@ defmodule NervesHubLink.UpdateManagerTest do
           update_available: update_available_fun
       }
 
-      {:ok, manager} = UpdateManager.start_link({fwup_config, %{}})
+      {:ok, manager} = UpdateManager.start_link({fwup_config, updater})
       assert UpdateManager.apply_update(manager, update_payload, []) == :update_rescheduled
       assert_received :rescheduled
       refute_received {:fwup, _}
@@ -71,7 +77,11 @@ defmodule NervesHubLink.UpdateManagerTest do
       assert_receive {:fwup, {:ok, 0, ""}}
     end
 
-    test "apply with fwup environment", %{update_payload: update_payload, devpath: devpath} do
+    test "apply with fwup environment", %{
+      update_payload: update_payload,
+      devpath: devpath,
+      updater: updater
+    } do
       fwup_config = %{
         default_config()
         | fwup_devpath: devpath,
@@ -83,8 +93,8 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       # If setting SUPER_SECRET in the environment doesn't happen, then test fails
       # due to fwup getting a bad aes key.
-      {:ok, manager} = UpdateManager.start_link({fwup_config, %{}})
-      assert UpdateManager.apply_update(manager, update_payload, []) == {:updating, 0}
+      {:ok, manager} = UpdateManager.start_link({fwup_config, updater})
+      assert UpdateManager.apply_update(manager, update_payload, []) == :updating
 
       assert_receive {:fwup, {:progress, 0}}
       assert_receive {:fwup, {:progress, 100}}

--- a/test/support/x_retry_number_plug.ex
+++ b/test/support/x_retry_number_plug.ex
@@ -14,6 +14,8 @@ defmodule NervesHubLink.Support.XRetryNumberPlug do
 
   import Plug.Conn
 
+  @content_length 4096
+
   @impl Plug
   def init(options), do: options
 
@@ -21,16 +23,28 @@ defmodule NervesHubLink.Support.XRetryNumberPlug do
   def call(conn, _opts) do
     retry_number = find_x_retry_number_header(conn.req_headers)
 
+    started_from = find_content_range_start_value(conn.req_headers)
+
     conn
     |> put_resp_header("accept-ranges", "bytes")
-    |> put_resp_header("content-length", "4096")
-    |> send_chunked(200)
-    |> do_stream(retry_number)
+    |> put_content_range_and_length(started_from)
+    |> send_chunked(206)
+    |> do_stream(retry_number, started_from)
   end
 
-  defp do_stream(conn, retry_number) do
-    {:ok, conn} = chunk(conn, :binary.copy(<<retry_number::8>>, 2048))
-    halt(conn)
+  defp do_stream(conn, retry_number, started_from) do
+    cond do
+      is_nil(started_from) ->
+        {:ok, conn} = chunk(conn, :binary.copy(<<retry_number::8>>, 2048))
+        halt(conn)
+
+      started_from + 2048 == @content_length ->
+        {:ok, conn} = chunk(conn, :binary.copy(<<retry_number::8>>, 2048))
+        chunk(conn, "")
+
+      true ->
+        raise("we shouldn't be here")
+    end
   end
 
   # i have no idea why get_req_header/2 doesn't work here.
@@ -39,4 +53,27 @@ defmodule NervesHubLink.Support.XRetryNumberPlug do
 
   defp find_x_retry_number_header([_ | rest]), do: find_x_retry_number_header(rest)
   defp find_x_retry_number_header([]), do: raise("Could not find x-retry-number header")
+
+  defp find_content_range_start_value([{"range", "bytes=" <> values} | _]) do
+    values
+    |> String.split("-")
+    |> hd()
+    |> String.to_integer()
+  end
+
+  defp find_content_range_start_value([_ | rest]), do: find_content_range_start_value(rest)
+  defp find_content_range_start_value([]), do: nil
+
+  defp put_content_range_and_length(conn, nil) do
+    put_resp_header(conn, "content-length", to_string(@content_length))
+  end
+
+  defp put_content_range_and_length(conn, starting_bytes) do
+    put_resp_header(
+      conn,
+      "content-range",
+      "bytes #{starting_bytes}-#{@content_length}/#{@content_length + 1}"
+    )
+    |> put_resp_header("content-length", to_string(@content_length - starting_bytes))
+  end
 end


### PR DESCRIPTION
This was inspired by #298 

With some simple changes to the `Downloader`, we can now stream chunks to a file. Couple this together with a set of `Updater`s, where different workflows associated with streaming straight to Fwup or from a file are encapsulated, we can now download firmware files to disk, which are recoverable between reboots, and then apply the updates once the download is complete.

I've given this a good testing with my dev RPI devices, and its working well.

Needs some docs, and some tests, and some tweaks on what statuses are reported and streamed to NH.

You can enable the new updater with:
```
config :nerves_hub_link,
  updater: NervesHubLink.UpdateManager.CachingUpdater
```

and you can configure where files are cached to using:
```
config :nerves_hub_link, CachingUpdater,
  cache_dir: "/data/my/dir/of/caches"
```
(the default is `/data/nerves_hub_link/firmware`)

You can also update the updater via iex using:
```
NervesHubLink.UpdateManager.change_updater(NervesHubLink.UpdateManager.StreamingUpdater)
```