### PR TITLE
Send firmware validation and auto revert status to NervesHub

### DIFF
--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -335,6 +335,7 @@ defmodule NervesHubLink.Client do
     previous_slot =
       KV.get_all()
       |> Enum.map(fn {k, v} -> {k, v} end)
+      |> Enum.reject(fn {k, _v} -> !String.match?(k, ~r/.\./) end)
       |> Enum.reject(fn {k, _v} -> String.starts_with?(k, "#{active_slot}.") end)
       |> Enum.map(fn {k, v} -> {String.replace(k, ~r/\A.{1}\./, ""), v} end)
       |> Enum.into(%{})

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -46,6 +46,7 @@ defmodule NervesHubLink.Client do
   ```
   """
 
+  alias Nerves.Runtime.KV
   alias NervesHubLink.Backoff
 
   require Logger
@@ -145,7 +146,25 @@ defmodule NervesHubLink.Client do
   """
   @callback reboot() :: no_return()
 
-  @optional_callbacks [connected: 0, reconnect_backoff: 0, reboot: 0]
+  @doc """
+  Optional callback to check if an auto firmware revert just occurred.
+
+  The default behavior is to check if the previous firmware slots:
+  - `nerves_fw_validated` value is `0`
+  - and `nerves_fw_platform` is not empty
+  - and `nerves_fw_architecture` is not empty
+
+  If there is custom logic built into `fwup-ops.conf` around `prevent-revert`, this should be
+  reflected here.
+  """
+  @callback firmware_auto_revert_detected?() :: boolean()
+
+  @optional_callbacks [
+    connected: 0,
+    firmware_auto_revert_detected?: 0,
+    reboot: 0,
+    reconnect_backoff: 0
+  ]
 
   @spec connected() :: any
   def connected() do
@@ -268,6 +287,61 @@ defmodule NervesHubLink.Client do
     else
       Backoff.delay_list(1000, 60000, 0.50)
     end
+  end
+
+  @doc """
+  The common logic to determine if an auto revert occurred is to check if the previous
+  firmware is not validated. This is because, for example, if a device boots into
+  firmware slot A and isn't able to validate the slot within the initialization
+  callback time, the device will reboot into the previous firmware slot, B, and now
+  firmware slot A will be shown as not validated.
+
+  We also need to account for the logic used by `prevent-revert` in `fwup-ops.conf`,
+  which can be different/custom per Nerves system. The common pattern is to unset
+  `nerves_fw_platform` and `nerves_fw_architecture`.
+
+  The default implementation checks if the previous firmware slot is not validated,
+  and that `nerves_fw_platform` and `nerves_fw_architecture` are not empty.
+
+  Clears platform and architecture uboot env vars
+  - https://github.com/nerves-project/nerves_system_rpi4/blob/main/fwup-ops.conf#L51-L52
+  - https://github.com/nerves-project/nerves_system_rpi5/blob/main/fwup-ops.conf#L51-L52
+
+  Clears platform, architecture, and validated uboot env vars
+  - https://github.com/nerves-project/nerves_system_rpi4/blob/tryboot-compatible/fwup-ops.conf#L50-L55
+  """
+  @spec firmware_auto_revert_detected?() :: boolean()
+  def firmware_auto_revert_detected?() do
+    if function_exported?(mod(), :firmware_auto_revert_detected?, 0) do
+      case apply_wrap(mod(), :firmware_auto_revert_detected?, []) do
+        is_reverted when is_boolean(is_reverted) ->
+          is_reverted
+
+        other ->
+          Logger.warning(
+            "[NervesHubLink.Client] Invalid response from `#{inspect(mod())}.firmware_auto_revert_detected?/0`, returning false : #{inspect(other)}"
+          )
+
+          false
+      end
+    else
+      default_firmware_auto_revert_check()
+    end
+  end
+
+  defp default_firmware_auto_revert_check() do
+    active_slot = KV.get("nerves_fw_active")
+
+    previous_slot =
+      KV.get_all()
+      |> Enum.map(fn {k, v} -> {k, v} end)
+      |> Enum.reject(fn {k, _v} -> String.starts_with?(k, "#{active_slot}.") end)
+      |> Enum.map(fn {k, v} -> {String.replace(k, ~r/\A.{1}\./, ""), v} end)
+      |> Enum.into(%{})
+
+    Map.get(previous_slot, "nerves_fw_validated", "1") == "0" &&
+      Map.get(previous_slot, "nerves_fw_platform", "") != "" &&
+      Map.get(previous_slot, "nerves_fw_architecture", "") != ""
   end
 
   # Catches exceptions and exits

--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -334,8 +334,9 @@ defmodule NervesHubLink.Client do
 
     previous_slot =
       KV.get_all()
-      |> Enum.reject(fn {k, _v} -> !String.match?(k, ~r/.\./) end)
-      |> Enum.reject(fn {k, _v} -> String.starts_with?(k, "#{active_slot}.") end)
+      |> Enum.filter(fn {k, _v} ->
+        String.match?(k, ~r/.\./) and not String.starts_with?(k, "#{active_slot}.")
+      end)
       |> Enum.map(fn {k, v} -> {String.replace(k, ~r/\A.{1}\./, ""), v} end)
       |> Enum.into(%{})
 

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -27,7 +27,7 @@ defmodule NervesHubLink.Configurator do
 
   require Logger
 
-  @device_api_version "2.2.0"
+  @device_api_version "2.3.0"
   @console_version "2.0.0"
 
   defmodule Config do

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -32,6 +32,8 @@ defmodule NervesHubLink.Socket do
   @device_topic "device"
   @extensions_topic "extensions"
 
+  @firmware_validation_check_interval :timer.seconds(10)
+
   @spec start_link(Configurator.Config.t()) :: GenServer.on_start()
   def start_link(config) do
     GenServer.start_link(__MODULE__, config, name: __MODULE__)
@@ -112,12 +114,17 @@ defmodule NervesHubLink.Socket do
   def init(config) do
     Alarms.set_alarm({NervesHubLink.Disconnected, []})
 
-    check_for_firmware_auto_revert()
+    alarm_if_firmware_auto_reverted()
+
+    params =
+      Map.put(config.params, "meta", %{
+        "firmware_auto_revert_detected" => Client.firmware_auto_revert_detected?()
+      })
 
     socket =
       new_socket()
       |> assign(config: config)
-      |> assign(params: config.params)
+      |> assign(params: params)
       |> assign(remote_iex: config.remote_iex)
       |> assign(iex_pid: nil)
       |> assign(iex_timer: nil)
@@ -126,6 +133,7 @@ defmodule NervesHubLink.Socket do
       |> assign(started_at: System.monotonic_time(:millisecond))
       |> assign(connected_at: nil)
       |> assign(joined_at: nil)
+      |> assign(firmware_validation_timer_pid: nil)
 
     if config.connect_wait_for_network do
       schedule_network_availability_check()
@@ -177,6 +185,8 @@ defmodule NervesHubLink.Socket do
     Alarms.clear_alarm(NervesHubLink.Disconnected)
 
     Client.connected()
+
+    socket = schedule_firmware_validation_status_check(socket)
 
     {:ok, socket}
   end
@@ -473,6 +483,20 @@ defmodule NervesHubLink.Socket do
     end
   end
 
+  def handle_info(:firmware_validation_status_check, socket) do
+    if KV.get("nerves_fw_validated") == "1" do
+      Logger.info("[NervesHubLink] Firmware is validated, notifying NervesHub")
+      _ = push(socket, @device_topic, "firmware_validated", %{})
+      {:noreply, assign(socket, :firmware_validation_timer_pid, nil)}
+    else
+      Logger.debug(
+        "[NervesHubLink] Firmware is not marked as validated, checking again in #{@firmware_validation_check_interval / 1000} seconds"
+      )
+
+      {:noreply, schedule_firmware_validation_status_check(socket)}
+    end
+  end
+
   def handle_info({"scripts/run", ref, output, return}, socket) do
     _ =
       push(socket, @device_topic, "scripts/run", %{
@@ -583,21 +607,11 @@ defmodule NervesHubLink.Socket do
     disconnect(socket)
   end
 
-  # It's highly probable that the previous firmware version was reverted if the previous slots
-  # firmware wasn't validated.
-  defp check_for_firmware_auto_revert() do
-    active_slot = KV.get("nerves_fw_active")
-
-    previous_slot_validated =
-      KV.get_all()
-      |> Enum.map(fn {k, v} -> {k, v} end)
-      |> Enum.reject(fn {k, _v} -> String.starts_with?(k, "#{active_slot}.") end)
-      |> Enum.map(fn {k, v} -> {String.replace(k, ~r/\A.{1}\./, ""), v} end)
-      |> Enum.into(%{})
-      |> Map.get("nerves_fw_validated", "1")
-
-    if previous_slot_validated == "0" do
+  defp alarm_if_firmware_auto_reverted() do
+    if Client.firmware_auto_revert_detected?() do
       Alarms.set_alarm({NervesHubLink.FirmwareReverted, []})
+    else
+      :ok
     end
   end
 
@@ -620,6 +634,27 @@ defmodule NervesHubLink.Socket do
   defp schedule_network_availability_check(delay \\ 100) do
     Process.send_after(self(), :connect_check_network_availability, delay)
   end
+
+  defp schedule_firmware_validation_status_check(socket) do
+    if socket.assigns.params["nerves_fw_validated"] == "1" do
+      Logger.debug("[NervesHubLink] Firmware validated and information sent during connection")
+      socket
+    else
+      _ = maybe_cancel_timer(socket.assigns[:firmware_validation_timer_pid])
+
+      pid =
+        Process.send_after(
+          self(),
+          :firmware_validation_status_check,
+          @firmware_validation_check_interval
+        )
+
+      assign(socket, :firmware_validation_timer_pid, pid)
+    end
+  end
+
+  defp maybe_cancel_timer(nil), do: :ok
+  defp maybe_cancel_timer(pid), do: Process.cancel_timer(pid)
 
   defp handle_join_reply(%{"firmware_url" => url} = update, socket) when is_binary(url) do
     case UpdateInfo.parse(update) do

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -116,15 +116,10 @@ defmodule NervesHubLink.Socket do
 
     alarm_if_firmware_auto_reverted()
 
-    params =
-      Map.put(config.params, "meta", %{
-        "firmware_auto_revert_detected" => Client.firmware_auto_revert_detected?()
-      })
-
     socket =
       new_socket()
       |> assign(config: config)
-      |> assign(params: params)
+      |> assign(params: config.params)
       |> assign(remote_iex: config.remote_iex)
       |> assign(iex_pid: nil)
       |> assign(iex_timer: nil)
@@ -175,6 +170,9 @@ defmodule NervesHubLink.Socket do
     device_join_params =
       socket.assigns.params
       |> Map.put("currently_downloading_uuid", currently_downloading_uuid)
+      |> Map.put("meta", %{
+        "firmware_auto_revert_detected" => Client.firmware_auto_revert_detected?()
+      })
 
     socket =
       socket

--- a/test/nerves_hub_link/client_test.exs
+++ b/test/nerves_hub_link/client_test.exs
@@ -18,6 +18,12 @@ defmodule NervesHubLink.ClientTest do
     Mox.verify_on_exit!(context)
   end
 
+  test "firmware_auto_revert_detected?/0" do
+    assert Client.firmware_auto_revert_detected?() == false
+    Mox.expect(ClientMock, :firmware_auto_revert_detected?, fn -> true end)
+    assert Client.firmware_auto_revert_detected?() == true
+  end
+
   test "connected/0" do
     Mox.expect(ClientMock, :connected, fn -> :ok end)
     assert Client.connected() == :ok


### PR DESCRIPTION
So that NervesHub can display firmware validation status, and if its prior firmware was recently reverted, this PR adds:

1. some extra meta data to the params we send during connection to include if an auto revert was detected
2. a timer to check if the current firmware has been validated, and then send a notification to NH when the firmware validation is detected
3. and finally, I've bumped the api version so we can determine on NervesHub if we are going to get a notification on a devices firmware validation status

This PR will have a corresponding PR for NervesHub, but first I want to get this change reviewed.

This additional information is important for NH because we should not send firmware updates to devices which haven't validated their current firmware (they will ignore the update request) and we can consider excluding devices from updating to the current firmware in a deployment if they just reverted from it, which could lead to them being stuck in an update-revert loop.

Plus, this information can be used for metrics within NervesHub, another win for detecting problems or issues within a fleet.

I've encapsulated the logic for reversion detection into `Client` so that it can be customized based on the Nerves system used. As noted in the docs of the `Client` function, the common logic to determine if an auto-revert occurred is to check if the previous firmware is not validated.  We also need to account for the logic used by `prevent-revert` in `fwup-ops.conf`, which can be different/custom per Nerves system. The common pattern is to unset `nerves_fw_platform` and `nerves_fw_architecture`, but I have come across some systems which also unset the `nerves_fw_validated` uboot env var. The default implementation checks if the previous firmware slot is not validated, and that `nerves_fw_platform` and `nerves_fw_architecture` are not empty.