### PR TITLE
Drop support for Elixir 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ tags:
     1.16.2-erlang-26.2.4-alpine-3.19.1,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.2-erlang-25.2-alpine-3.16.3,
-    1.13.4-erlang-24.3.4.10-alpine-3.17.2
   ]
 
 jobs:

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule NervesHubLink.MixProject do
       description: @description,
       dialyzer: dialyzer(),
       docs: docs(),
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       preferred_cli_env: [


### PR DESCRIPTION
Nerves [doesn't support 1.13](https://github.com/nerves-project/nerves/blob/main/mix.exs#L11), and [Elixir's compatibility list](https://hexdocs.pm/elixir/compatibility-and-deprecations.html) declares 1.14 as the minimum. We're starting to experience issues with [dependencies on 1.13](https://app.circleci.com/pipelines/github/nerves-hub/nerves_hub_link/1171/workflows/2feb9f28-6e4a-4fc0-b61b-d726db5180e2/jobs/5499), so it's time to move forward.