### PR TITLE
Add an optional `Client` callback for checking firmware validation

### DIFF
--- a/test/nerves_hub_link/client_test.exs
+++ b/test/nerves_hub_link/client_test.exs
@@ -18,6 +18,12 @@ defmodule NervesHubLink.ClientTest do
     Mox.verify_on_exit!(context)
   end
 
+  test "firmware_validated?/0" do
+    assert Client.firmware_validated?() == true
+    Mox.expect(ClientMock, :firmware_validated?, fn -> false end)
+    assert Client.firmware_validated?() == false
+  end
+
   test "firmware_auto_revert_detected?/0" do
     assert Client.firmware_auto_revert_detected?() == false
     Mox.expect(ClientMock, :firmware_auto_revert_detected?, fn -> true end)


### PR DESCRIPTION
This modifies the recently merged in #331 by delegating the firmware validation check to the device (via `Client`) instead of having NervesHub decide this.

The reason is two-fold:

1. having NervesHub decide if a firmware is valid requires all devices to implement the same logic in their KV data, which isn't the case.
2. and by using an optional callback on `Client` (with a default implementation) we can allow for developers to customize this logic.

This will require a change in NervesHub. A PR will follow shortly.