### PR TITLE
Update join params with meta information

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -175,6 +175,7 @@ defmodule NervesHubLink.Socket do
 
     socket =
       socket
+      |> assign(params: device_join_params)
       |> join(@device_topic, device_join_params)
       |> maybe_join_console()
       |> assign(connected_at: System.monotonic_time(:millisecond))


### PR DESCRIPTION
The scheduling of the firmware validation status check relies on inspecting the params in the socket assigns to check if the firmware was initially known to be validated.

This small change updates the params in assigns for the check can work as expected.