### PR TITLE
Add logging that helps indicate clock issues

### DIFF
--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -46,7 +46,7 @@ defmodule NervesHubLink.Configurator.SharedSecret do
       |> Keyword.put(:signed_at, System.os_time(:second))
 
     datetime = DateTime.from_unix!(opts[:signed_at]) |> DateTime.to_iso8601()
-    Logger.info("Generating auth headers with time #{datetime}")
+    Logger.info("[NervesHubLink:SharedSecret] Generating auth headers with time #{datetime}")
 
     alg =
       "#{opts[:signature_version]}-HMAC-#{opts[:key_digest]}-#{opts[:key_iterations]}-#{opts[:key_length]}"


### PR DESCRIPTION
We had a bunch of people dealing with time making shared secrets not work for the Goatmire badge. I have sometimes thought I had that problem when my clock was correct and there were other issues on the backend. This should make it easier to know what time the device is working with when creating the auth header.