### PR TITLE
Allow additional fwup args to be configured

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -177,6 +177,14 @@ You can disable this behaviour with the following config:
 config :nerves_hub_link, connect_wait_for_network: false
 ```
 
+## Providing additional fwup arguments
+
+To pass additional arguments supported by the fwup CLI, you can pass a list of strings via the `:fwup_extra_options` key.
+
+```elixir
+config :nerves_hub_link, fwup_extra_options: ["--unsafe"],
+```
+
 ## Disable `NervesHubLink` during testing
 
 To disable `NervesHubLink` connecting to `NervesHub` when testing, you can add:

--- a/lib/nerves_hub_link/application.ex
+++ b/lib/nerves_hub_link/application.ex
@@ -28,6 +28,7 @@ defmodule NervesHubLink.Application do
         fwup_config = %FwupConfig{
           fwup_devpath: config.fwup_devpath,
           fwup_task: config.fwup_task,
+          fwup_extra_options: config.fwup_extra_options,
           fwup_env: config.fwup_env
         }
 

--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -47,6 +47,7 @@ defmodule NervesHubLink.Configurator do
               fwup_devpath: "/dev/mmcblk0",
               fwup_env: [],
               fwup_public_keys: [],
+              fwup_extra_options: [],
               fwup_task: "upgrade",
               heartbeat_interval_msec: 30_000,
               host: "localhost",

--- a/lib/nerves_hub_link/fwup_config.ex
+++ b/lib/nerves_hub_link/fwup_config.ex
@@ -13,11 +13,13 @@ defmodule NervesHubLink.FwupConfig do
 
   defstruct fwup_devpath: "",
             fwup_env: [],
+            fwup_extra_options: [],
             fwup_task: ""
 
   @type t :: %__MODULE__{
           fwup_devpath: Path.t(),
           fwup_task: String.t(),
+          fwup_extra_options: [String.t()],
           fwup_env: [{String.t(), String.t()}]
         }
 

--- a/lib/nerves_hub_link/update_manager/caching_updater.ex
+++ b/lib/nerves_hub_link/update_manager/caching_updater.ex
@@ -177,16 +177,17 @@ defmodule NervesHubLink.UpdateManager.CachingUpdater do
   end
 
   defp fwup_args(%FwupConfig{} = config, firmware_path, fwup_public_keys) do
-    args = [
-      "--apply",
-      "--no-unmount",
-      "-d",
-      config.fwup_devpath,
-      "--task",
-      config.fwup_task,
-      "-i",
-      firmware_path
-    ]
+    args =
+      [
+        "--apply",
+        "--no-unmount",
+        "-d",
+        config.fwup_devpath,
+        "--task",
+        config.fwup_task,
+        "-i",
+        firmware_path
+      ] ++ config.fwup_extra_options
 
     Enum.reduce(fwup_public_keys, args, fn public_key, args ->
       args ++ ["--public-key", public_key]

--- a/lib/nerves_hub_link/update_manager/streaming_updater.ex
+++ b/lib/nerves_hub_link/update_manager/streaming_updater.ex
@@ -66,7 +66,15 @@ defmodule NervesHubLink.UpdateManager.StreamingUpdater do
 
   @spec fwup_args(FwupConfig.t(), list(String.t())) :: [String.t()]
   defp fwup_args(%FwupConfig{} = config, fwup_public_keys) do
-    args = ["--apply", "--no-unmount", "-d", config.fwup_devpath, "--task", config.fwup_task]
+    args =
+      [
+        "--apply",
+        "--no-unmount",
+        "-d",
+        config.fwup_devpath,
+        "--task",
+        config.fwup_task
+      ] ++ config.fwup_extra_options
 
     Enum.reduce(fwup_public_keys, args, fn public_key, args ->
       args ++ ["--public-key", public_key]


### PR DESCRIPTION
This is an important escape hatch. For example, providing the `--unsafe` flag allows otherwise unsupported flash to be updated via NervesHub using fwup `execute` commands.