### PR TITLE
Revert remote_iex_timeout units back to seconds

### DIFF
--- a/lib/nerves_hub_link/configurator.ex
+++ b/lib/nerves_hub_link/configurator.ex
@@ -55,7 +55,7 @@ defmodule NervesHubLink.Configurator do
               params: %{},
               rejoin_after: [5_000],
               remote_iex: false,
-              remote_iex_timeout: 5 * 60 * 1000,
+              remote_iex_timeout: 5 * 60,
               request_archive_public_keys: false,
               request_fwup_public_keys: false,
               shared_secret: [],

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -745,7 +745,7 @@ defmodule NervesHubLink.Socket do
   end
 
   defp set_iex_timer(socket) do
-    timeout = socket.assigns.config.remote_iex_timeout
+    timeout = socket.assigns.config.remote_iex_timeout * 1000
 
     maybe_cancel_timer(socket.assigns[:iex_timer])
 


### PR DESCRIPTION
#359 changed the units for remote_iex_timeout from seconds to ms which breaks config backwards compatibility.