### PR TITLE
Send :status message to UpdateManager by default

### DIFF
--- a/lib/nerves_hub_link.ex
+++ b/lib/nerves_hub_link.ex
@@ -21,6 +21,7 @@ defmodule NervesHubLink do
   """
 
   alias NervesHubLink.Socket
+  alias NervesHubLink.UpdateManager
 
   @type update_status ::
           :received
@@ -74,8 +75,8 @@ defmodule NervesHubLink do
   @doc """
   Current status of the update manager
   """
-  @spec status(GenServer.server()) :: NervesHubLink.UpdateManager.status()
-  defdelegate status(server \\ Socket), to: NervesHubLink.UpdateManager
+  @spec status(GenServer.server()) :: UpdateManager.status()
+  defdelegate status(server \\ UpdateManager), to: UpdateManager
 
   @doc """
   Restart the socket and device channel


### PR DESCRIPTION
This message isn't handled by `Socket` anymore, it's handled by [`UpdateManager`](https://github.com/nerves-hub/nerves_hub_link/blob/fix-default-arg-status/lib/nerves_hub_link/update_manager.ex#L62), so the default should reflect.