### PR TITLE
Add erlang socket address resolution to network interface

### DIFF
--- a/lib/nerves_hub_link/network_interface.ex
+++ b/lib/nerves_hub_link/network_interface.ex
@@ -14,7 +14,8 @@ defmodule NervesHubLink.NetworkInterface do
   Get the network interface from a Slipstream.Socket or Mint.HTTP struct. This is used to report the
   network interface being used for the connection to NervesHub and for firmware downloads.
   """
-  @spec from_socket(:ssl.socket() | :inet.socket() | Mint.Types.socket()) :: nil | binary()
+  @spec from_socket(:ssl.socket() | :inet.socket() | :socket.socket() | Mint.Types.socket()) ::
+          nil | binary()
   def from_socket(socket) do
     address_from_socket(socket)
     |> interface_from_address()
@@ -32,6 +33,11 @@ defmodule NervesHubLink.NetworkInterface do
 
   defp address_from_socket(socket) when is_port(socket) do
     {:ok, {address, _}} = :inet.sockname(socket)
+    address
+  end
+
+  defp address_from_socket(socket) when is_reference(socket) do
+    {:ok, %{addr: address}} = :socket.sockname(socket)
     address
   end
 

--- a/lib/nerves_hub_link/network_interface.ex
+++ b/lib/nerves_hub_link/network_interface.ex
@@ -31,13 +31,13 @@ defmodule NervesHubLink.NetworkInterface do
     address
   end
 
-  defp address_from_socket(socket) when is_port(socket) do
-    {:ok, {address, _}} = :inet.sockname(socket)
+  defp address_from_socket(socket) when is_tuple(socket) and elem(socket, 0) == :"$socket" do
+    {:ok, %{addr: address}} = :socket.sockname(socket)
     address
   end
 
-  defp address_from_socket(socket) when is_reference(socket) do
-    {:ok, %{addr: address}} = :socket.sockname(socket)
+  defp address_from_socket(socket) when is_port(socket) do
+    {:ok, {address, _}} = :inet.sockname(socket)
     address
   end
 


### PR DESCRIPTION
Fixes #417
Adding a function header to match erlang sockets in netwrok interface.