### PR TITLE
Adjust the worst case timeout to work better with smaller files

### DIFF
--- a/lib/nerves_hub_link/downloader.ex
+++ b/lib/nerves_hub_link/downloader.ex
@@ -248,11 +248,8 @@ defmodule NervesHubLink.Downloader do
   # schedules a message to be delivered based on retry args
   @spec reschedule_resume(t()) :: resume_rescheduled()
   defp reschedule_resume(%Downloader{retry_number: retry_number} = state) do
-    # cancel the worst_case_timeout if it was running
-    worst_case_timeout_remaining_ms =
-      if state.worst_case_timeout do
-        Process.cancel_timer(state.worst_case_timeout) || nil
-      end
+    # cancel the worst_case_timeout if it exists
+    _ = if state.worst_case_timeout, do: Process.cancel_timer(state.worst_case_timeout)
 
     timer = Process.send_after(self(), :resume, state.retry_args.time_between_retries)
 
@@ -261,26 +258,17 @@ defmodule NervesHubLink.Downloader do
       | request_ref: nil,
         retry_timeout: timer,
         retry_number: retry_number + 1,
-        worst_case_timeout_remaining_ms: worst_case_timeout_remaining_ms
+        worst_case_timeout_remaining_ms: nil
     }
   end
 
-  @spec schedule_worst_case_timer(t()) :: t()
-  # only calculate worst_case_timeout_remaining_ms if it's nil (i.e. not set)
-  defp schedule_worst_case_timer(%Downloader{worst_case_timeout_remaining_ms: nil} = downloader) do
+  defp schedule_worst_case_timer(downloader) do
     # decompose here because in the formatter doesn't like all this being in the head
     %Downloader{retry_args: retry_config, content_length: content_length} = downloader
     %RetryConfig{worst_case_download_speed: speed} = retry_config
     ms = TimeoutCalculation.calculate_worst_case_timeout(content_length, speed)
     timer = Process.send_after(self(), :worst_case_download_speed_timeout, ms)
-    %Downloader{downloader | worst_case_timeout: timer}
-  end
-
-  # worst_case_timeout_remaining_ms gets set if the timer gets canceled by reschedule_resume/1
-  # this is done so that the timer doesn't keep counting while not actively downloading data
-  defp schedule_worst_case_timer(%Downloader{worst_case_timeout_remaining_ms: ms} = downloader) do
-    timer = Process.send_after(self(), :worst_case_download_speed_timeout, ms)
-    %Downloader{downloader | worst_case_timeout: timer}
+    %{downloader | worst_case_timeout: timer}
   end
 
   defp handle_responses([response | rest], %Downloader{} = state) do

--- a/lib/nerves_hub_link/downloader/timeout_calculation.ex
+++ b/lib/nerves_hub_link/downloader/timeout_calculation.ex
@@ -15,7 +15,7 @@ defmodule NervesHubLink.Downloader.TimeoutCalculation do
   @spec calculate_worst_case_timeout(number_of_bytes, bits_per_second) :: non_neg_integer()
   def calculate_worst_case_timeout(content_length, speed) do
     # need to extract milliseconds based on a speed in seconds and number of bits
-    # set a max of 1 minute in case the data is smaller than the conceivably fastest speed
-    round(content_length * 8 / speed * 1000) |> max(60_000)
+    # set a minimum of 5 minutes in case the data is smaller than the conceivably fastest speed
+    round(content_length * 8 / speed * 1000) |> max(300_000)
   end
 end

--- a/test/nerves_hub_link/downloader/timeout_calculation_test.exs
+++ b/test/nerves_hub_link/downloader/timeout_calculation_test.exs
@@ -15,6 +15,6 @@ defmodule NervesHubLink.Downloader.TimeoutCalculationTest do
   test "calculate_worst_case_timeout minimum value" do
     # small data now matter how slow finishes quickly
     # ensure there's a minimum timeout of 60000 ms
-    assert TimeoutCalculation.calculate_worst_case_timeout(1, 30_000) == 60000
+    assert TimeoutCalculation.calculate_worst_case_timeout(1, 30_000) == 300_000
   end
 end


### PR DESCRIPTION
The previous calculation, while correct, doesn't work well for small files downloaded over slow connections, such as NB-IoT.

This PR changes two things
1. the timeout is recalculated when the download is resumed
2. the minimum timeout is 5mins