### PR TITLE
Network interface reporting improvements

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,7 +21,7 @@
     "youngblood",
 
     // Technical terms
-    "nolink",
+    "Geolocation",
     "backoffs",
     "bingenerate",
     "configurator",
@@ -29,12 +29,13 @@
     "disksup",
     "expty",
     "fwupdate",
-    "Geolocation",
     "geoip",
+    "getaddr",
     "getcap",
     "kbps",
     "maint",
     "nerveshub",
+    "nolink",
     "nvread",
     "privkey",
     "reconnections",

--- a/lib/nerves_hub_link/downloader.ex
+++ b/lib/nerves_hub_link/downloader.ex
@@ -511,7 +511,7 @@ defmodule NervesHubLink.Downloader do
     with {:ok, conn} <-
            Mint.HTTP.connect(String.to_existing_atom(scheme), host, port, connect_opts),
          {:ok, conn, request_ref} <- Mint.HTTP.request(conn, "GET", path, request_headers, nil),
-         :ok <- report_download_started(conn) do
+         :ok <- NervesHubLink.send_update_status({:started, NetworkInterface.from_uri(uri)}) do
       {:ok,
        %Downloader{
          state
@@ -568,11 +568,6 @@ defmodule NervesHubLink.Downloader do
   defp close_conn(%Downloader{conn: conn}) do
     {:ok, _} = Mint.HTTP.close(conn)
     :ok
-  end
-
-  defp report_download_started(conn) do
-    downloader_network_interface = NetworkInterface.from_socket(Mint.HTTP.get_socket(conn))
-    NervesHubLink.send_update_status({:started, downloader_network_interface})
   end
 
   # Shallow-merge user-supplied opts on top of the base, but for :transport_opts

--- a/lib/nerves_hub_link/network_interface.ex
+++ b/lib/nerves_hub_link/network_interface.ex
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Josh Kalderimis
 # SPDX-FileCopyrightText: 2026 Nate Shoemaker
-#
+# SPDX-FileCopyrightText: 2026 Ky Bishop
+
 # SPDX-License-Identifier: Apache-2.0
 #
 defmodule NervesHubLink.NetworkInterface do
@@ -11,54 +12,92 @@ defmodule NervesHubLink.NetworkInterface do
   require Logger
 
   @doc """
-  Get the network interface from a Slipstream.Socket or Mint.HTTP struct. This is used to report the
-  network interface being used for the connection to NervesHub and for firmware downloads.
+  Determine the network interface used to reach the given URI.
+
+  Opens a UDP socket and connects it to the target host/port. This is a purely
+  local kernel routing-table lookup — no packets are sent to the server. The local
+  address assigned to the socket reveals which interface the OS would use, which is
+  then matched against the system interface list.
   """
-  @spec from_socket(:ssl.socket() | :inet.socket() | :socket.socket() | Mint.Types.socket()) ::
-          nil | binary()
-  def from_socket(socket) do
-    address_from_socket(socket)
-    |> interface_from_address()
+  @spec from_uri(URI.t()) :: nil | binary()
+  def from_uri(%URI{host: host, port: port}) do
+    with {:ok, ip} <- resolve(host),
+         {:ok, udp} <- :gen_udp.open(0, [socket_family(ip)]) do
+      result =
+        with :ok <- :gen_udp.connect(udp, ip, port || 443),
+             {:ok, {local_ip, _}} <- :inet.sockname(udp) do
+          interface_from_address(local_ip)
+        else
+          error ->
+            Logger.warning(
+              "[NervesHubLink.NetworkInterface] Could not determine network interface for #{host}: #{inspect(error)}"
+            )
+
+            nil
+        end
+
+      :gen_udp.close(udp)
+
+      result
+    else
+      error ->
+        Logger.warning(
+          "[NervesHubLink.NetworkInterface] Could not determine network interface for #{host}: #{inspect(error)}"
+        )
+
+        nil
+    end
   rescue
     err ->
-      Logger.warning("[NervesHubLink] Could not retrieve network interface: #{inspect(err)}")
+      Logger.warning(
+        "[NervesHubLink.NetworkInterface] Could not determine network interface: #{inspect(err)}"
+      )
 
       nil
   end
 
-  defp address_from_socket(socket) when is_tuple(socket) and elem(socket, 0) == :sslsocket do
-    {:ok, {address, _}} = :ssl.sockname(socket)
-    address
-  end
+  defp socket_family({_, _, _, _}), do: :inet
+  defp socket_family({_, _, _, _, _, _, _, _}), do: :inet6
 
-  defp address_from_socket(socket) when is_tuple(socket) and elem(socket, 0) == :"$socket" do
-    {:ok, %{addr: address}} = :socket.sockname(socket)
-    address
-  end
+  defp resolve(host) do
+    charlist = String.to_charlist(host)
 
-  defp address_from_socket(socket) when is_port(socket) do
-    {:ok, {address, _}} = :inet.sockname(socket)
-    address
-  end
-
-  defp address_from_socket(socket) do
-    Logger.warning(
-      "[NervesHubLink] Could not retrieve network interface from socket: #{inspect(socket)}"
-    )
-
-    nil
+    case :inet.getaddr(charlist, :inet) do
+      {:ok, _} = ok -> ok
+      {:error, _} -> :inet.getaddr(charlist, :inet6)
+    end
   end
 
   defp interface_from_address(address) do
-    {:ok, interfaces} = :inet.getifaddrs()
+    with {:ok, interfaces} <- get_interfaces(),
+         {:ok, interface_name} <- find_interface_by_address(interfaces, address) do
+      List.to_string(interface_name)
+    end
+  end
 
-    case Enum.find(interfaces, fn {_name, attrs} -> attrs[:addr] == address end) do
-      {interface, _attrs} ->
-        # charlist -> string
-        List.to_string(interface)
+  defp get_interfaces() do
+    with {:error, reason} <- :inet.getifaddrs() do
+      Logger.warning(
+        "[NervesHubLink.NetworkInterface] Could not list network interfaces: #{inspect(reason)}"
+      )
 
+      nil
+    end
+  end
+
+  defp find_interface_by_address(interfaces, address) do
+    case Enum.find(interfaces, fn {_name, attrs} ->
+           Enum.any?(attrs, &(&1 == {:addr, address}))
+         end) do
       nil ->
+        Logger.warning(
+          "[NervesHubLink.NetworkInterface] No network interface found with local address #{inspect(address)}"
+        )
+
         nil
+
+      {interface_name, _attrs} ->
+        {:ok, interface_name}
     end
   end
 end

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -150,7 +150,8 @@ defmodule NervesHubLink.Socket do
       uri: config.socket[:url],
       rejoin_after_msec: List.flatten([config.rejoin_after]),
       reconnect_after_msec: config.socket[:reconnect_after_msec],
-      heartbeat_interval_msec: config.heartbeat_interval_msec
+      heartbeat_interval_msec: config.heartbeat_interval_msec,
+      test_mode?: Keyword.get(config.socket, :test_mode?, false)
     ]
 
     socket = connect!(socket, opts)
@@ -614,17 +615,17 @@ defmodule NervesHubLink.Socket do
   end
 
   def handle_info(:get_network_interface, socket) do
-    with pid when is_pid(pid) <- Slipstream.Socket.channel_pid(socket),
-         %{conn: conn} <- :sys.get_state(pid),
-         underlying_socket = Mint.HTTP.get_socket(conn),
-         interface when is_binary(interface) <- NetworkInterface.from_socket(underlying_socket) do
-      _ = push(socket, @device_topic, "report_network_interface", %{interface: interface})
-      {:noreply, assign(socket, network_interface: interface)}
-    else
-      result ->
-        Logger.warning(
-          "[NervesHubLink] Could not determine network interface: #{inspect(result)}"
-        )
+    case NetworkInterface.from_uri(socket.assigns.config.socket[:url]) do
+      interface when is_binary(interface) ->
+        _ =
+          if interface != socket.assigns[:network_interface] do
+            push(socket, @device_topic, "report_network_interface", %{interface: interface})
+          end
+
+        {:noreply, assign(socket, network_interface: interface)}
+
+      _ ->
+        Logger.warning("[NervesHubLink] Could not determine network interface, will retry in 60s")
 
         Process.send_after(self(), :get_network_interface, 60_000)
         {:noreply, socket}

--- a/test/nerves_hub_link/network_interface_test.exs
+++ b/test/nerves_hub_link/network_interface_test.exs
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Ky Bishop
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.NetworkInterfaceTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias NervesHubLink.NetworkInterface
+
+  describe "from_uri/1" do
+    test "identifies the loopback interface for a localhost URI" do
+      # Routing to 127.0.0.1 always selects the loopback interface (lo on Linux, lo0 on macOS).
+      log =
+        capture_log(fn ->
+          result = NetworkInterface.from_uri(%URI{host: "127.0.0.1", port: 80})
+          assert String.starts_with?(result, "lo")
+        end)
+
+      refute log =~ "[NervesHubLink.NetworkInterface]"
+    end
+
+    test "defaults port to 443 when port is nil" do
+      # wss:// URIs have no registered default port in Elixir's URI module, so the field arrives
+      # as nil. The routing lookup ignores the port for the kernel route decision, so the result
+      # must match the plain IPv4 case above.
+      log =
+        capture_log(fn ->
+          result = NetworkInterface.from_uri(%URI{host: "127.0.0.1", port: nil})
+          assert String.starts_with?(result, "lo")
+        end)
+
+      refute log =~ "[NervesHubLink.NetworkInterface]"
+    end
+
+    test "identifies the loopback interface for an IPv6 localhost URI" do
+      # ::1 fails IPv4 resolution, triggering resolve/1's :inet6 fallback.
+      # The socket must be opened with [:inet6] to connect to the IPv6 address.
+      # Also exercises Enum.any? matching IPv6 tuples in inet.getifaddrs attrs.
+      log =
+        capture_log(fn ->
+          result = NetworkInterface.from_uri(%URI{host: "::1", port: 80})
+          assert String.starts_with?(result, "lo")
+        end)
+
+      refute log =~ "[NervesHubLink.NetworkInterface]"
+    end
+
+    test "returns nil and logs when the host cannot be resolved" do
+      # An empty string causes :inet.getaddr to return {:error, :einval} immediately — no DNS
+      # query, no network dependency.
+      log =
+        capture_log(fn ->
+          assert NetworkInterface.from_uri(%URI{host: "", port: 443}) == nil
+        end)
+
+      assert log =~ "[NervesHubLink.NetworkInterface] Could not determine network interface for"
+    end
+
+    test "returns nil and logs when host is nil" do
+      # String.to_charlist(nil) raises ArgumentError; the rescue block must catch it and return nil.
+      log =
+        capture_log(fn ->
+          assert NetworkInterface.from_uri(%URI{host: nil, port: 443}) == nil
+        end)
+
+      assert log =~ "[NervesHubLink.NetworkInterface] Could not determine network interface"
+    end
+  end
+end

--- a/test/nerves_hub_link/socket_network_interface_test.exs
+++ b/test/nerves_hub_link/socket_network_interface_test.exs
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Ky Bishop
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.Socket.NetworkInterfaceTest do
+  # Slipstream.SocketTest simulates the test process as the remote server,
+  # so tests must run synchronously to avoid cross-test interference.
+  use Slipstream.SocketTest
+
+  import Mox
+
+  alias NervesHubLink.Configurator.Config
+  alias NervesHubLink.FwupConfig
+  alias NervesHubLink.UpdateManager
+
+  # Tests are async: false (Slipstream.SocketTest requirement), so global Mox mode is safe
+  # and avoids the chicken-and-egg problem of allowing a pid that doesn't exist yet.
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    stub(NervesHubLink.ClientMock, :connected, fn -> :ok end)
+    stub(NervesHubLink.ClientMock, :firmware_validated?, fn -> true end)
+    stub(NervesHubLink.ClientMock, :firmware_auto_revert_detected?, fn -> false end)
+    stub(NervesHubLink.ClientMock, :handle_error, fn _reason -> :ok end)
+    # Zero-delay reconnect so disconnect/reconnect cycle completes without sleeping.
+    stub(NervesHubLink.ClientMock, :reconnect_backoff, fn -> [0] end)
+
+    config = %Config{
+      socket: [
+        url: URI.parse("ws://127.0.0.1:80/socket"),
+        test_mode?: true,
+        reconnect_after_msec: [0]
+      ],
+      connect_wait_for_network: false,
+      remote_iex: false
+    }
+
+    start_supervised!(%{
+      id: UpdateManager,
+      start:
+        {UpdateManager, :start_link,
+         [
+           {%FwupConfig{}, NervesHubLink.UpdateManager.UpdaterMock},
+           [name: NervesHubLink.UpdateManager]
+         ]}
+    })
+
+    client = start_supervised!({NervesHubLink.Socket, config})
+
+    %{client: client}
+  end
+
+  test "reports network interface on first join", %{client: client} do
+    connect_and_assert_join(client, "device", %{}, :ok)
+
+    assert_push("device", "report_network_interface", %{interface: interface})
+    assert is_binary(interface)
+  end
+
+  test "does not push when interface is unchanged after a second check", %{client: client} do
+    connect_and_assert_join(client, "device", %{}, :ok)
+    assert_push("device", "report_network_interface", %{interface: _} = params)
+
+    # Trigger a second lookup — interface is the same, no push should fire.
+    send(client, :get_network_interface)
+
+    refute_push("device", "report_network_interface", ^params)
+  end
+
+  test "does not re-push network interface on reconnect when interface is unchanged", %{
+    client: client
+  } do
+    connect_and_assert_join(client, "device", %{}, :ok)
+    assert_push("device", "report_network_interface", %{interface: _} = params)
+
+    # Simulate the server closing the connection (e.g. a flapping device heartbeat timeout).
+    disconnect(client, :heartbeat_timeout)
+
+    # The socket reconnects and rejoins the device topic.
+    connect_and_assert_join(client, "device", %{}, :ok)
+
+    # The interface assign persists across the reconnect cycle — no duplicate push.
+    refute_push("device", "report_network_interface", ^params)
+  end
+end


### PR DESCRIPTION
This PR was started to deal with a breakage between OTP 27 -> OTP 28. I stepped back to see if there was a more stable way of determining network interface, and landed on this UDP socket approach.

1. No data is ever sent to the server
2. This should be more stable between upgrades, both in elixir/otp and deps like slipstream and mint
3. We now only send network interface data if it changed between the last attempt, which should help with flapping devices

This approach has been tested on my device running OTP 28 and the latest nerves_system_br