### PR TITLE
Recover SharedSecret signing when the device clock is wrong

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -38,6 +38,7 @@
     "nvread",
     "privkey",
     "reconnections",
+    "strftime",
     "subkey",
     "vcgencmd",
     "whenwhere"

--- a/lib/nerves_hub_link/configurators/shared_secret.ex
+++ b/lib/nerves_hub_link/configurators/shared_secret.ex
@@ -30,10 +30,18 @@ defmodule NervesHubLink.Configurator.SharedSecret do
   end
 
   @doc """
-  Generate headers for Shared Secret Auth
+  Generate headers for Shared Secret Auth.
+
+  Accepts an optional `server_time` hint — a `DateTime` previously
+  observed on a server response. When the hint is ahead of the device
+  clock it's used as `signed_at`; otherwise the device clock wins. This
+  is how a device with a wrong local clock (no RTC, NTP not yet synced)
+  can still produce a signature the server accepts on retry.
   """
-  @spec headers(Config.t()) :: [{String.t(), String.t()}]
-  def headers(%{shared_secret: shared_secret}) do
+  @spec headers(Config.t(), DateTime.t() | nil) :: [{String.t(), String.t()}]
+  def headers(config, server_time \\ nil)
+
+  def headers(%{shared_secret: shared_secret}, server_time) do
     opts =
       (shared_secret || [])
       |> Keyword.put_new(:key_digest, :sha256)
@@ -41,9 +49,10 @@ defmodule NervesHubLink.Configurator.SharedSecret do
       |> Keyword.put_new(:key_length, 32)
       |> Keyword.put_new(:signature_version, "NH1")
       |> Keyword.put_new(:identifier, Nerves.Runtime.serial_number())
-      # Important to use os_time as system_time is not updated by Erlang as
-      # quickly. See https://www.erlang.org/doc/apps/erts/time_correction#erlang-system-time
-      |> Keyword.put(:signed_at, System.os_time(:second))
+      # Important to use os_time, not system_time — Erlang's system_time
+      # is corrected gradually rather than snapping to wall-clock changes.
+      # See https://www.erlang.org/doc/apps/erts/time_correction#erlang-system-time
+      |> Keyword.put(:signed_at, effective_signed_at(server_time))
 
     datetime = DateTime.from_unix!(opts[:signed_at]) |> DateTime.to_iso8601()
     Logger.info("[NervesHubLink:SharedSecret] Generating auth headers with time #{datetime}")
@@ -74,6 +83,50 @@ defmodule NervesHubLink.Configurator.SharedSecret do
       {"x-nh-time", to_string(opts[:signed_at])},
       {"x-nh-signature", Plug.Crypto.sign(secret, salt, opts[:identifier], opts)}
     ]
+  end
+
+  @doc """
+  Extract a server-time hint from a Slipstream disconnect reason.
+
+  Slipstream surfaces Mint's WebSocket upgrade failures as
+  `{:error, {:upgrade_failure, %{reason: %UpgradeFailureError{headers: ...}}}}`.
+  When that's the shape we get, parse the server's RFC 9110 `Date`
+  header (e.g. `Sun, 06 Nov 1994 08:49:37 GMT`) into a `DateTime` and
+  return it. Returns `nil` for any other reason shape, or if the Date
+  header is missing or malformed.
+  """
+  @spec server_time_hint(term()) :: DateTime.t() | nil
+  def server_time_hint({:error, {:upgrade_failure, %{reason: %{headers: headers}}}})
+      when is_list(headers) do
+    with {_, date_str} <- Enum.find(headers, fn {k, _v} -> k == "date" end),
+         {:ok, dt} <- parse_http_date(date_str) do
+      dt
+    else
+      _ -> nil
+    end
+  end
+
+  def server_time_hint(_), do: nil
+
+  # max(device clock, server hint). A hint older than the device clock
+  # becomes a no-op, so a device whose clock has caught up since the
+  # hint was learned just uses its own time.
+  defp effective_signed_at(nil), do: System.os_time(:second)
+
+  defp effective_signed_at(%DateTime{} = server_time) do
+    max(System.os_time(:second), DateTime.to_unix(server_time))
+  end
+
+  defp parse_http_date(str) when is_binary(str) do
+    case :httpd_util.convert_request_date(String.to_charlist(str)) do
+      {{_, _, _}, {_, _, _}} = datetime ->
+        epoch = :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+        unix = :calendar.datetime_to_gregorian_seconds(datetime) - epoch
+        DateTime.from_unix(unix)
+
+      _ ->
+        :error
+    end
   end
 
   # Currently only support NH1

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -662,8 +662,13 @@ defmodule NervesHubLink.Socket do
         SharedSecret ->
           # TODO: I don't know when reconnect/1 actually gets validated. It could be that
           # the signature we create here will be too old before the headers are used
-          # in a connection attempt again
-          headers = SharedSecret.headers(socket.assigns.config)
+          # in a connection attempt again.
+          #
+          # When the failed upgrade response carried a `Date` header, sign
+          # with that time instead of the device clock — recovers devices
+          # whose RTC/NTP isn't trustworthy yet.
+          hint = SharedSecret.server_time_hint(reason)
+          headers = SharedSecret.headers(socket.assigns.config, hint)
           %{channel_config | headers: headers}
 
         _ ->

--- a/test/nerves_hub_link/configurators/shared_secret_test.exs
+++ b/test/nerves_hub_link/configurators/shared_secret_test.exs
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2026 Lars Wikman
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.Configurator.SharedSecretTest do
+  use ExUnit.Case, async: true
+
+  alias Mint.WebSocket.UpgradeFailureError
+  alias NervesHubLink.Configurator.Config
+  alias NervesHubLink.Configurator.SharedSecret
+
+  defp config() do
+    %Config{
+      shared_secret: [
+        product_key: "nhp_test",
+        product_secret: "test-secret",
+        identifier: "tnh-unit-test"
+      ]
+    }
+  end
+
+  defp signed_at(headers) do
+    {_, value} = Enum.find(headers, fn {k, _} -> k == "x-nh-time" end)
+    {ts, ""} = Integer.parse(value)
+    ts
+  end
+
+  defp upgrade_failure(status_code, headers) do
+    {:error,
+     {:upgrade_failure,
+      %{reason: %UpgradeFailureError{status_code: status_code, headers: headers}}}}
+  end
+
+  # RFC 9110 format (the form Bandit emits in every response).
+  defp http_date(%DateTime{} = dt) do
+    Calendar.strftime(dt, "%a, %d %b %Y %H:%M:%S GMT")
+  end
+
+  describe "headers/2" do
+    test "without a server time hint, x-nh-time is the device clock" do
+      first = signed_at(SharedSecret.headers(config()))
+      second = signed_at(SharedSecret.headers(config()))
+
+      # os_time advances at 1 Hz, so two near-simultaneous calls differ
+      # by 0 or 1 second.
+      assert (second - first) in 0..1
+    end
+
+    test "a server time hint ahead of the device clock is used as signed_at" do
+      future = DateTime.utc_now() |> DateTime.add(1_000, :second)
+
+      ts = signed_at(SharedSecret.headers(config(), future))
+
+      assert_in_delta ts, DateTime.to_unix(future), 1
+    end
+
+    test "a server time hint behind the device clock is ignored" do
+      past = DateTime.utc_now() |> DateTime.add(-10_000, :second)
+
+      baseline = signed_at(SharedSecret.headers(config()))
+      shifted = signed_at(SharedSecret.headers(config(), past))
+
+      assert (shifted - baseline) in 0..1
+    end
+  end
+
+  describe "server_time_hint/1" do
+    test "returns the parsed DateTime from a 4xx upgrade failure" do
+      dt = ~U[2030-01-03 12:34:56Z]
+      reason = upgrade_failure(401, [{"date", http_date(dt)}])
+
+      assert SharedSecret.server_time_hint(reason) == dt
+    end
+
+    test "is nil for non-upgrade-failure reasons" do
+      assert SharedSecret.server_time_hint({:error, :closed}) == nil
+      assert SharedSecret.server_time_hint(:normal) == nil
+    end
+
+    test "is nil when the response has no Date header" do
+      reason = upgrade_failure(401, [{"content-type", "text/plain"}])
+      assert SharedSecret.server_time_hint(reason) == nil
+    end
+
+    test "is nil when the Date header is malformed" do
+      reason = upgrade_failure(401, [{"date", "not a real date"}])
+      assert SharedSecret.server_time_hint(reason) == nil
+    end
+
+    test "matches only Mint's lowercased header convention" do
+      # Mint lowercases response header names; server_time_hint/1 looks
+      # for "date" exactly. Verify it does NOT match the capitalized form
+      # so we'd notice if Mint ever stopped normalizing.
+      reason = upgrade_failure(401, [{"Date", "Fri, 03 Jan 2030 12:34:56 GMT"}])
+      assert SharedSecret.server_time_hint(reason) == nil
+    end
+  end
+end


### PR DESCRIPTION
SharedSecret auth signs with the device clock and assumes it's within ~90s of the server. New devices often boot with a clock far off reality and can take a long time to recover, blocking the first connection.

When a connection fails, pick up the `Date` header from the response and use it as the signing time on the next attempt. If the device clock has since caught up past the hint, the device clock wins.

A nonce exchange would be cleaner but needs server cooperation; this is a backwards compatible device side workaround.