### PR TITLE
Add support for `Nerves.Runtime.firmware_slots/0`

### DIFF
--- a/lib/nerves_hub_link/client.ex
+++ b/lib/nerves_hub_link/client.ex
@@ -389,7 +389,13 @@ defmodule NervesHubLink.Client do
   end
 
   defp default_firmware_auto_revert_check() do
-    active_slot = KV.get("nerves_fw_active")
+    active_slot =
+      if function_exported?(Nerves.Runtime, :firmware_slots, 0) do
+        %{active: active} = Nerves.Runtime.firmware_slots()
+        active
+      else
+        KV.get("nerves_fw_active")
+      end
 
     previous_slot =
       KV.get_all()


### PR DESCRIPTION
Newer versions of Nerves use `Nerves.Runtime.firmware_slots/0` instead of `KV.get("nerves_fw_active")`