### PR TITLE
Remove timestamp that prevented reproducible builds

### DIFF
--- a/lib/nerves_hub_link/extensions/health/device_status.ex
+++ b/lib/nerves_hub_link/extensions/health/device_status.ex
@@ -9,7 +9,7 @@ defmodule NervesHubLink.Extensions.Health.DeviceStatus do
   """
 
   @derive Jason.Encoder
-  defstruct timestamp: DateTime.utc_now(),
+  defstruct timestamp: DateTime.from_gregorian_seconds(0),
             metadata: %{},
             alarms: %{},
             metrics: %{},


### PR DESCRIPTION
Every time DeviceStatus was rebuilt, the beam file would change due to
the compile-time timestamp.

Fixes #415.
