### PR TITLE
Send only the protocol versions when joining the console

### DIFF
--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -833,9 +833,14 @@ defmodule NervesHubLink.Socket do
     end
   end
 
+  # The console only needs to know which protocol versions it is talking to.
+  # The rest of the join params describe the device and its firmware, and the
+  # device channel has already sent them.
+  @console_join_params ["console_version", "device_api_version"]
+
   defp maybe_join_console(socket) do
     if socket.assigns.remote_iex do
-      join(socket, @console_topic, socket.assigns.params)
+      join(socket, @console_topic, Map.take(socket.assigns.params, @console_join_params))
     else
       socket
     end

--- a/test/nerves_hub_link/socket_messages_test.exs
+++ b/test/nerves_hub_link/socket_messages_test.exs
@@ -390,6 +390,35 @@ defmodule NervesHubLink.SocketMessagesTest do
     end
   end
 
+  describe "joining topics" do
+    @describetag socket_config: [
+                   remote_iex: true,
+                   params: %{
+                     "console_version" => "2.0.0",
+                     "device_api_version" => "2.3.0",
+                     "nerves_fw_uuid" => "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8",
+                     "nerves_fw_version" => "1.0.0",
+                     "serial_number" => "test-device"
+                   }
+                 ]
+
+    test "the device join describes the device and its firmware" do
+      assert_join(@device_topic, params, :error)
+
+      assert params["device_api_version"] == "2.3.0"
+      assert params["nerves_fw_uuid"] == "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8"
+      assert params["serial_number"] == "test-device"
+      assert params["currently_downloading_uuid"] == nil
+      assert %{"firmware_validated" => true} = params["meta"]
+    end
+
+    test "the console join carries only the protocol versions" do
+      assert_join(@console_topic, params, :error)
+
+      assert params == %{"console_version" => "2.0.0", "device_api_version" => "2.3.0"}
+    end
+  end
+
   describe "reporting the network interface" do
     # Joining the device topic makes the client inspect the connection process
     # with `:sys.get_state/2`. Under test that process is this one, which


### PR DESCRIPTION
Extracted from #443, where it was bundled with the Msgpack serializer work. It's a server-visible change to what the device sends, so it deserves its own review.

## What changes

The console join carried the full device join payload — firmware uuid, version, serial number, `currently_downloading_uuid`, and the validation metadata. It now carries only `console_version` and `device_api_version`.

Everything dropped was already sent on the device channel over the same socket moments earlier, so NervesHub isn't losing information — it's receiving it once instead of twice. Every device sends this on every connect and reconnect, so it's a small saving repeated a lot, which is worth having on metered connections.

## What to check before merging

Please confirm nothing on the server's console channel reads anything else off those join params. That's the one thing this PR can't verify from the device side.

## Tests

Two tests pin what each topic receives: the device join still describes the device and its firmware, and the console join carries only the two versions. The console one fails without the change.

## Base branch

Stacked on #453, which adds the socket test infrastructure this uses. GitHub will retarget it to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
