### PR TITLE
Test against Elixir 1.20.3 and OTP 29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - elixir: "1.20.3"
+            otp: "29.0"
           - elixir: "1.19.5"
             otp: "28.5"
           - elixir: "1.18.4"

--- a/lib/nerves_hub_link/extensions/extensions.ex
+++ b/lib/nerves_hub_link/extensions/extensions.ex
@@ -207,31 +207,32 @@ defmodule NervesHubLink.Extensions do
   end
 
   def handle_cast({:handle_event, event, payload}, state) do
-    results =
+    delivered? =
       case String.split(event, ":", parts: 2) do
         [extension, event] ->
           case state.extensions[extension] do
             %{module: module} ->
               try do
-                send(module, {:__extension_event__, event, payload})
+                _ = send(module, {:__extension_event__, event, payload})
+                true
               rescue
                 error ->
                   Logger.error(
                     "[NervesHubLink.Extensions] Error handling event `#{inspect(event)}` with payload `#{inspect(payload)}`: #{inspect(error)}"
                   )
 
-                  nil
+                  false
               end
 
             _ ->
-              nil
+              false
           end
 
         _ ->
-          nil
+          false
       end
 
-    if results == [] do
+    if not delivered? do
       # Event was unhandled. Maybe report it to NH?
       Logger.warning(
         "[NervesHubLink.Extensions] Unhandled event: #{inspect(event)} - #{inspect(payload)}"


### PR DESCRIPTION
Adds Elixir 1.20.3 / OTP 29.0 to the test matrix.

## A fix has to come first

Elixir 1.20's type system rejects `main` under `--warnings-as-errors`:

```
lib/nerves_hub_link/extensions/extensions.ex:234:16
    dynamic(nil or {:__extension_event__, term(), term()}) == empty_list()
    ...you are comparing across types which are always disjoint
```

It's right. `handle_cast({:handle_event, ...})` decided whether an event went unhandled by comparing `results` against `[]`, but `results` is either `nil` or whatever `send/2` returned — never a list. The warning could never fire, so an event naming an extension that isn't running, or an event whose name doesn't split into an extension and an event, was dropped in silence. First commit fixes that; second adds the matrix entry.

## Verified locally

On OTP 29.0.5 with Elixir 1.20.3: compiles clean with `--warnings-as-errors`, all 60 tests pass, and credo, dialyzer and the formatter are happy. Re-checked on the current lint toolchain (OTP 27.3.4 / Elixir 1.18.4) so the fix doesn't disturb what's already there.

One thing to know for future work: Elixir 1.20 renamed the ExUnit summary line from `60 tests, 0 failures` to `Result: 60 passed`. Nothing in CI greps for it, but anything that does will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
