### PR TITLE
Rename external identity to network identity

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -7,7 +7,7 @@ There are four extensions currently:
 - [**Geo**](#geo) provides hooks to send a device's GeoIP information.
 - [**Health**](#health) reports device metrics, alarms, metadata and similar.
 - [**Local Shell**](#local-shell) gives NervesHub the ability to expose an interactive shell in the UI.
-- [**External Identity**](#external-identity) reports the device's identity on networks NervesHub doesn't run, such as iroh or NetBird.
+- [**Network Identity**](#external-identity) reports the device's identity on networks NervesHub doesn't run, such as iroh or NetBird.
 
 Your NervesHub server controls enabling and disabling extensions to allow you to switch them off if they impact operations.
 
@@ -135,7 +135,7 @@ This extension is enabled by default, but must also be enabled in your Device an
 
 To use this extension, you need to include the [`ExPTY`](https://hex.pm/packages/expty) library in your project's dependencies.
 
-## External Identity
+## Network Identity
 
 Devices increasingly reach the outside world over something other than their NervesHub socket — an iroh endpoint, a NetBird or Tailscale peer, a plain WireGuard interface. Each of those networks names the device by a long-lived public key, and that key is what you need in order to reach it by any route other than NervesHub.
 
@@ -145,7 +145,7 @@ There is no default provider, and there can't be one: NervesHubLink has no way t
 
 ```elixir
 config :nerves_hub_link,
-  external_identity: [
+  network_identity: [
     providers: [MyApp.IrohIdentity]
   ]
 ```
@@ -154,11 +154,11 @@ One provider reports one service. A device on both iroh and NetBird configures t
 
 ### Writing a provider
 
-Implement `NervesHubLink.Extensions.ExternalIdentity.Provider`, which is a single `identity/0` callback. For a device running [`iroh_console`](https://hex.pm/packages/iroh_console):
+Implement `NervesHubLink.Extensions.NetworkIdentity.Provider`, which is a single `identity/0` callback. For a device running [`iroh_console`](https://hex.pm/packages/iroh_console):
 
 ```elixir
 defmodule MyApp.IrohIdentity do
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
   @impl true
   def identity() do
@@ -199,7 +199,7 @@ The same shape works for anything else. A NetBird provider is really just parsin
 
 ```elixir
 defmodule MyApp.NetBirdIdentity do
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
   @impl true
   def identity() do
@@ -242,13 +242,13 @@ Keep `details` small — NervesHub rejects a payload over 4KB once encoded — a
 NervesHub asks once per connection, because an identity is long-lived and polling for it would be noise. If something changes while the device stays connected, announce it yourself:
 
 ```elixir
-NervesHubLink.Extensions.ExternalIdentity.send_report()
+NervesHubLink.Extensions.NetworkIdentity.send_report()
 ```
 
 To see what your providers currently return without sending anything, which is the quickest way to work out why a device isn't showing what you expect:
 
 ```elixir
-NervesHubLink.Extensions.ExternalIdentity.identities()
+NervesHubLink.Extensions.NetworkIdentity.identities()
 ```
 
 Like every extension, this must also be enabled in your Product and Device settings on your NervesHub platform.

--- a/lib/nerves_hub_link/extensions/extensions.ex
+++ b/lib/nerves_hub_link/extensions/extensions.ex
@@ -28,7 +28,7 @@ defmodule NervesHubLink.Extensions do
   @default_extension_modules [
                                NervesHubLink.Extensions.Health,
                                NervesHubLink.Extensions.Geo,
-                               NervesHubLink.Extensions.ExternalIdentity
+                               NervesHubLink.Extensions.NetworkIdentity
                              ] ++
                                if(Code.ensure_loaded?(ExPTY),
                                  do: [NervesHubLink.Extensions.LocalShell],

--- a/lib/nerves_hub_link/extensions/network_identity/network_identity.ex
+++ b/lib/nerves_hub_link/extensions/network_identity/network_identity.ex
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-defmodule NervesHubLink.Extensions.ExternalIdentity do
+defmodule NervesHubLink.Extensions.NetworkIdentity do
   @moduledoc """
-  The External Identity Extension.
+  The Network Identity Extension.
 
   Reports the identities this device holds on networks NervesHub does not run —
   an iroh endpoint id, a NetBird or Tailscale peer key, a WireGuard public key —
@@ -13,10 +13,10 @@ defmodule NervesHubLink.Extensions.ExternalIdentity do
 
   Nothing is reported unless you configure at least one provider, because
   NervesHubLink cannot discover these on its own. See
-  `NervesHubLink.Extensions.ExternalIdentity.Provider`.
+  `NervesHubLink.Extensions.NetworkIdentity.Provider`.
 
       config :nerves_hub_link,
-        external_identity: [providers: [MyApp.IrohIdentity]]
+        network_identity: [providers: [MyApp.IrohIdentity]]
 
   Unlike `NervesHubLink.Extensions.Health` and
   `NervesHubLink.Extensions.Geo` there is no interval: an identity is long-lived,
@@ -25,19 +25,19 @@ defmodule NervesHubLink.Extensions.ExternalIdentity do
   IP — call `send_report/0` to announce it.
   """
 
-  use NervesHubLink.Extensions, name: "external_identity", version: "0.0.1"
+  use NervesHubLink.Extensions, name: "network_identity", version: "0.0.1"
 
   require Logger
 
   @doc """
-  Report this device's external identities to NervesHub now.
+  Report this device's network identities to NervesHub now.
 
   Only needed when something changed mid-connection; NervesHub asks for a report
   on its own when the extension attaches.
 
   ## Examples
 
-      iex> NervesHubLink.Extensions.ExternalIdentity.send_report()
+      iex> NervesHubLink.Extensions.NetworkIdentity.send_report()
       :ok
 
   """
@@ -83,7 +83,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentity do
       # The server only asks when an operator has switched this on, so being
       # asked with nothing configured is worth saying out loud.
       Logger.warning(
-        "[#{inspect(__MODULE__)}] NervesHub asked for external identities but no providers are configured"
+        "[#{inspect(__MODULE__)}] NervesHub asked for network identities but no providers are configured"
       )
     end
 
@@ -190,7 +190,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentity do
   @spec providers() :: [module()]
   defp providers() do
     :nerves_hub_link
-    |> Application.get_env(:external_identity, [])
+    |> Application.get_env(:network_identity, [])
     |> Keyword.get(:providers, [])
     |> List.wrap()
   end

--- a/lib/nerves_hub_link/extensions/network_identity/provider.ex
+++ b/lib/nerves_hub_link/extensions/network_identity/provider.ex
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-defmodule NervesHubLink.Extensions.ExternalIdentity.Provider do
+defmodule NervesHubLink.Extensions.NetworkIdentity.Provider do
   @moduledoc """
   Behaviour for reporting an identity this device holds on another network.
 
@@ -17,7 +17,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentity.Provider do
   ## Writing one
 
       defmodule MyApp.IrohIdentity do
-        @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+        @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
         @impl true
         def identity() do
@@ -39,7 +39,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentity.Provider do
   And then:
 
       config :nerves_hub_link,
-        external_identity: [providers: [MyApp.IrohIdentity]]
+        network_identity: [providers: [MyApp.IrohIdentity]]
 
   ## Returning `:unavailable` rather than an error
 

--- a/mix.exs
+++ b/mix.exs
@@ -89,8 +89,8 @@ defmodule NervesHubLink.MixProject do
         ],
         Extensions: [
           NervesHubLink.Extensions,
-          NervesHubLink.Extensions.ExternalIdentity,
-          NervesHubLink.Extensions.ExternalIdentity.Provider,
+          NervesHubLink.Extensions.NetworkIdentity,
+          NervesHubLink.Extensions.NetworkIdentity.Provider,
           NervesHubLink.Extensions.Geo,
           NervesHubLink.Extensions.Geo.DefaultResolver,
           NervesHubLink.Extensions.Geo.Resolver,

--- a/test/nerves_hub_link/extensions/network_identity_test.exs
+++ b/test/nerves_hub_link/extensions/network_identity_test.exs
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.IrohProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.IrohProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity() do
     {:ok,
      %{
@@ -17,114 +17,114 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest.IrohProvider do
   end
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.NetBirdProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.NetBirdProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity() do
     {:ok, %{service: "netbird", identifier: "peer-key-9000"}}
   end
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.StringKeyedProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.StringKeyedProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity() do
     {:ok,
      %{"service" => "tailscale", "identifier" => "nodekey-abc", "details" => %{"os" => "linux"}}}
   end
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.ConsoleInstanceProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.ConsoleInstanceProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity() do
     {:ok, %{service: "iroh", instance: "iroh_console", identifier: "console-key"}}
   end
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.AtomInstanceProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.AtomInstanceProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity() do
     {:ok, %{service: :iroh, instance: :iroh_console, identifier: "atom-instance-key"}}
   end
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.BlankInstanceProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.BlankInstanceProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity() do
     {:ok, %{service: "iroh", instance: "", identifier: "blank-instance-key"}}
   end
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.UnavailableProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.UnavailableProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity(), do: :unavailable
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.ErroringProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.ErroringProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity(), do: {:error, :endpoint_not_started}
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.RaisingProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.RaisingProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity(), do: raise("the endpoint is on fire")
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest.ConfusedProvider do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest.ConfusedProvider do
   @moduledoc false
-  @behaviour NervesHubLink.Extensions.ExternalIdentity.Provider
+  @behaviour NervesHubLink.Extensions.NetworkIdentity.Provider
 
-  @impl NervesHubLink.Extensions.ExternalIdentity.Provider
+  @impl NervesHubLink.Extensions.NetworkIdentity.Provider
   def identity(), do: {:ok, %{service: "iroh"}}
 end
 
-defmodule NervesHubLink.Extensions.ExternalIdentityTest do
+defmodule NervesHubLink.Extensions.NetworkIdentityTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog, only: [capture_log: 1, with_log: 1]
 
-  alias NervesHubLink.Extensions.ExternalIdentity
-  alias NervesHubLink.Extensions.ExternalIdentityTest.AtomInstanceProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.BlankInstanceProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.ConfusedProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.ConsoleInstanceProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.ErroringProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.IrohProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.NetBirdProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.RaisingProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.StringKeyedProvider
-  alias NervesHubLink.Extensions.ExternalIdentityTest.UnavailableProvider
+  alias NervesHubLink.Extensions.NetworkIdentity
+  alias NervesHubLink.Extensions.NetworkIdentityTest.AtomInstanceProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.BlankInstanceProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.ConfusedProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.ConsoleInstanceProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.ErroringProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.IrohProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.NetBirdProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.RaisingProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.StringKeyedProvider
+  alias NervesHubLink.Extensions.NetworkIdentityTest.UnavailableProvider
 
   setup do
-    previous = Application.get_env(:nerves_hub_link, :external_identity)
+    previous = Application.get_env(:nerves_hub_link, :network_identity)
 
     on_exit(fn ->
       if previous do
-        Application.put_env(:nerves_hub_link, :external_identity, previous)
+        Application.put_env(:nerves_hub_link, :network_identity, previous)
       else
-        Application.delete_env(:nerves_hub_link, :external_identity)
+        Application.delete_env(:nerves_hub_link, :network_identity)
       end
     end)
 
@@ -132,18 +132,18 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
   end
 
   defp put_providers(providers) do
-    Application.put_env(:nerves_hub_link, :external_identity, providers: providers)
+    Application.put_env(:nerves_hub_link, :network_identity, providers: providers)
   end
 
   describe "identities/0" do
     test "reports nothing when no providers are configured" do
-      assert ExternalIdentity.identities() == []
+      assert NetworkIdentity.identities() == []
     end
 
     test "collects one identity per provider" do
       put_providers([IrohProvider, NetBirdProvider])
 
-      assert [iroh, netbird] = ExternalIdentity.identities()
+      assert [iroh, netbird] = NetworkIdentity.identities()
       assert iroh.service == "iroh"
       assert iroh.identifier == "e13b8a4c9f2d"
       assert iroh.details == %{"relay_url" => "https://iroh.nervescloud.com"}
@@ -154,13 +154,13 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test "an atom service is normalized to a string for the wire" do
       put_providers([IrohProvider])
 
-      assert [%{service: "iroh"}] = ExternalIdentity.identities()
+      assert [%{service: "iroh"}] = NetworkIdentity.identities()
     end
 
     test "details defaults to an empty map when a provider omits it" do
       put_providers([NetBirdProvider])
 
-      assert [%{details: %{}}] = ExternalIdentity.identities()
+      assert [%{details: %{}}] = NetworkIdentity.identities()
     end
 
     test "a string-keyed identity is accepted too" do
@@ -169,19 +169,19 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
       put_providers([StringKeyedProvider])
 
       assert [%{service: "tailscale", identifier: "nodekey-abc", details: %{"os" => "linux"}}] =
-               ExternalIdentity.identities()
+               NetworkIdentity.identities()
     end
 
     test "an instance is passed through when a provider names one" do
       put_providers([ConsoleInstanceProvider])
 
-      assert [%{instance: "iroh_console"}] = ExternalIdentity.identities()
+      assert [%{instance: "iroh_console"}] = NetworkIdentity.identities()
     end
 
     test "an atom instance is stringified for the wire" do
       put_providers([AtomInstanceProvider])
 
-      assert [%{instance: "iroh_console"}] = ExternalIdentity.identities()
+      assert [%{instance: "iroh_console"}] = NetworkIdentity.identities()
     end
 
     test "no instance key is sent when a provider doesn't name one" do
@@ -189,21 +189,21 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
       # library guessing at the name for it.
       put_providers([IrohProvider])
 
-      assert [identity] = ExternalIdentity.identities()
+      assert [identity] = NetworkIdentity.identities()
       refute Map.has_key?(identity, :instance)
     end
 
     test "a blank or unusable instance is left out rather than sent" do
       put_providers([BlankInstanceProvider])
 
-      assert [identity] = ExternalIdentity.identities()
+      assert [identity] = NetworkIdentity.identities()
       refute Map.has_key?(identity, :instance)
     end
 
     test "a single provider can be configured without a list" do
-      Application.put_env(:nerves_hub_link, :external_identity, providers: IrohProvider)
+      Application.put_env(:nerves_hub_link, :network_identity, providers: IrohProvider)
 
-      assert [%{service: "iroh"}] = ExternalIdentity.identities()
+      assert [%{service: "iroh"}] = NetworkIdentity.identities()
     end
   end
 
@@ -211,7 +211,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test ":unavailable is quiet, because it happens on every reconnect" do
       put_providers([UnavailableProvider])
 
-      log = capture_log(fn -> assert ExternalIdentity.identities() == [] end)
+      log = capture_log(fn -> assert NetworkIdentity.identities() == [] end)
 
       refute log =~ "[warning]"
     end
@@ -219,7 +219,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test "an error is reported and the provider skipped" do
       put_providers([ErroringProvider])
 
-      log = capture_log(fn -> assert ExternalIdentity.identities() == [] end)
+      log = capture_log(fn -> assert NetworkIdentity.identities() == [] end)
 
       assert log =~ "failed to resolve an identity"
       assert log =~ "endpoint_not_started"
@@ -228,7 +228,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test "a provider that raises does not take the extension with it" do
       put_providers([RaisingProvider])
 
-      log = capture_log(fn -> assert ExternalIdentity.identities() == [] end)
+      log = capture_log(fn -> assert NetworkIdentity.identities() == [] end)
 
       assert log =~ "the endpoint is on fire"
     end
@@ -236,7 +236,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test "an identity missing its identifier is skipped and named" do
       put_providers([ConfusedProvider])
 
-      log = capture_log(fn -> assert ExternalIdentity.identities() == [] end)
+      log = capture_log(fn -> assert NetworkIdentity.identities() == [] end)
 
       assert log =~ "without :service and :identifier"
       assert log =~ "ConfusedProvider"
@@ -245,7 +245,7 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test "one broken provider does not cost the others their identities" do
       put_providers([RaisingProvider, IrohProvider, ErroringProvider, NetBirdProvider])
 
-      {identities, _log} = with_log(fn -> ExternalIdentity.identities() end)
+      {identities, _log} = with_log(fn -> NetworkIdentity.identities() end)
 
       assert [%{service: "iroh"}, %{service: "netbird"}] = identities
     end
@@ -257,11 +257,11 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
       _ = start_supervised!({DynamicSupervisor, name: NervesHubLink.ExtensionsSupervisor})
       _ = start_supervised!(NervesHubLink.Extensions)
 
-      :ok = NervesHubLink.Extensions.attach(["external_identity"])
+      :ok = NervesHubLink.Extensions.attach(["network_identity"])
 
       # attach/1 is a cast, so wait for the extension to be running before
       # anything calls into it.
-      wait_for_process(ExternalIdentity)
+      wait_for_process(NetworkIdentity)
 
       :ok
     end
@@ -269,18 +269,18 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
     test "answers a request from the server with the collected identities" do
       put_providers([IrohProvider])
 
-      send(ExternalIdentity, {:__extension_event__, "request", %{}})
+      send(NetworkIdentity, {:__extension_event__, "request", %{}})
 
-      assert_receive {:pushed, "extensions", "external_identity:report", payload}, 1_000
+      assert_receive {:pushed, "extensions", "network_identity:report", payload}, 1_000
       assert [%{service: "iroh", identifier: "e13b8a4c9f2d"}] = payload.identities
     end
 
     test "send_report/0 announces without being asked" do
       put_providers([NetBirdProvider])
 
-      assert ExternalIdentity.send_report() == :ok
+      assert NetworkIdentity.send_report() == :ok
 
-      assert_receive {:pushed, "extensions", "external_identity:report", payload}, 1_000
+      assert_receive {:pushed, "extensions", "network_identity:report", payload}, 1_000
       assert [%{service: "netbird"}] = payload.identities
     end
 
@@ -289,11 +289,11 @@ defmodule NervesHubLink.Extensions.ExternalIdentityTest do
       # provider list almost certainly means a half-finished setup.
       log =
         capture_log(fn ->
-          assert ExternalIdentity.send_report() == :ok
+          assert NetworkIdentity.send_report() == :ok
         end)
 
       assert log =~ "no providers are configured"
-      assert_receive {:pushed, "extensions", "external_identity:report", %{identities: []}}, 1_000
+      assert_receive {:pushed, "extensions", "network_identity:report", %{identities: []}}, 1_000
     end
   end
 


### PR DESCRIPTION
Every service this reports a key for is a network: iroh, NetBird, Tailscale, WireGuard. "External" was carrying only the information that the network is somebody else's, which is the least interesting thing about it.
