### PR TITLE
Fix `CachingUpdater` never clearing the cache on a rejected range request

### DIFF
--- a/lib/nerves_hub_link/update_manager/caching_updater.ex
+++ b/lib/nerves_hub_link/update_manager/caching_updater.ex
@@ -111,9 +111,17 @@ defmodule NervesHubLink.UpdateManager.CachingUpdater do
      })}
   end
 
-  def handle_downloader_message({:error, {:http_error, 404}}, state) do
+  # The `Downloader` wraps HTTP status errors in a `Mint.HTTPError` before
+  # handing them to the updater, so this has to match the struct and not a bare
+  # `{:http_error, status}` tuple.
+  #
+  # A 404 or a 416 (Range Not Satisfiable) in response to a range request is
+  # usually a sign that the partial we're resuming from no longer matches the
+  # object being served, so the cache is dropped to allow a clean retry.
+  def handle_downloader_message({:error, %Mint.HTTPError{reason: {:http_error, status}}}, state)
+      when status in [404, 416] do
     Logger.error(
-      "[#{log_prefix()}] 404 error. This could be related to incorrect ranges. Cleaning up any partials which may exist."
+      "[#{log_prefix()}] #{status} error. This could be related to incorrect ranges. Cleaning up any partials which may exist."
     )
 
     settings()[:cache_dir]

--- a/lib/nerves_hub_link/update_manager/updater.ex
+++ b/lib/nerves_hub_link/update_manager/updater.ex
@@ -182,7 +182,7 @@ defmodule NervesHubLink.UpdateManager.Updater do
       end
 
       def handle_info({:EXIT, download_pid, reason}, %{download: download_pid} = state) do
-        Logger.debug("[#{log_prefix()}] Downloader exited with reason \"#{reason}\"")
+        Logger.debug("[#{log_prefix()}] Downloader exited with reason #{inspect(reason)}")
         cleanup(state)
         {:stop, {:shutdown, {:download_error, reason}}, state}
       end

--- a/test/nerves_hub_link/update_manager/caching_updater_test.exs
+++ b/test/nerves_hub_link/update_manager/caching_updater_test.exs
@@ -8,7 +8,7 @@ defmodule NervesHubLink.UpdateManager.CachingUpdaterTest do
   alias NervesHubLink.ClientMock
   alias NervesHubLink.FwupConfig
   alias NervesHubLink.Message.{FirmwareMetadata, UpdateInfo}
-  alias NervesHubLink.Support.{FWUPStreamPlug, Utils}
+  alias NervesHubLink.Support.{FWUPStreamPlug, HTTPErrorPlug, Utils}
   alias NervesHubLink.UpdateManager.CachingUpdater
 
   setup do
@@ -85,5 +85,42 @@ defmodule NervesHubLink.UpdateManager.CachingUpdaterTest do
 
     # `FWUPStreamPlug` serves firmware whose `upgrade` task writes this payload
     assert File.read!(ctx.devpath) =~ "Hello, world!"
+  end
+
+  # `NervesHubLink.Downloader` reports HTTP status errors as
+  # `{:error, %Mint.HTTPError{reason: {:http_error, status}}}`. `CachingUpdater`
+  # used to match on a bare `{:error, {:http_error, 404}}` tuple, so the clause
+  # never ran and a stale partial could leave a device unable to ever update.
+  for status <- [404, 416] do
+    test "the cache directory is cleared when a resumed download is rejected with a #{status}",
+         ctx do
+      status = unquote(status)
+
+      Process.flag(:trap_exit, true)
+
+      {:ok, _plug, port} = Utils.supervise_plug(HTTPErrorPlug, status: status)
+
+      update_info = %UpdateInfo{
+        firmware_url: URI.parse("http://localhost:#{port}/test.fw"),
+        firmware_meta: %FirmwareMetadata{}
+      }
+
+      # a stale partial from an earlier attempt. `start/1` keeps this file (it
+      # only clears the *other* files in the cache) and resumes from it, which
+      # is what gets the range request rejected.
+      partial = Path.join(ctx.cache_dir, "test.fw.partial")
+      :ok = File.mkdir_p(ctx.cache_dir)
+      :ok = File.write(partial, "stale partial contents")
+
+      fwup_config = %FwupConfig{fwup_devpath: ctx.devpath, fwup_task: "upgrade"}
+
+      {:ok, updater} = CachingUpdater.start_link(update_info, fwup_config, [])
+
+      assert_receive {:EXIT, ^updater, {:shutdown, {:download_error, {:http_error, ^status}}}},
+                     5_000
+
+      refute File.exists?(partial)
+      assert File.ls!(ctx.cache_dir) == []
+    end
   end
 end

--- a/test/support/http_error_plug.ex
+++ b/test/support/http_error_plug.ex
@@ -9,12 +9,17 @@ defmodule NervesHubLink.Support.HTTPErrorPlug do
 
   import Plug.Conn
 
+  alias Plug.Conn.Status
+
+  @default_status 416
+
   @impl Plug
   def init(options), do: options
 
   @impl Plug
-  def call(conn, _opts) do
-    conn
-    |> send_resp(416, "Range Not Satisfiable")
+  def call(conn, opts) do
+    status = Keyword.get(opts, :status, @default_status)
+
+    send_resp(conn, status, Status.reason_phrase(status))
   end
 end


### PR DESCRIPTION
## The problem

The CHANGELOG for 2.12.0 says:

> `NervesHubLink.UpdateManager.CachingUpdater` now clears the cache directory when it sees a 404 during a partial-range download, allowing recovery from stale/invalid partial files (#411)

That never happened. `CachingUpdater` matched on a bare tuple:

```elixir
def handle_downloader_message({:error, {:http_error, 404}}, state) do
```

but `NervesHubLink.Downloader` wraps the status in a `Mint.HTTPError` before handing it to the updater (`downloader.ex:337`):

```elixir
state.handler_fun.({:error, %Mint.HTTPError{reason: {:http_error, status}}})
```

So the clause was dead code. The message fell through to the generic `{:error, reason}` clause and was only logged, the cache was never cleared, and a stale or invalid partial file could leave a device unable to ever update — every subsequent attempt resumes from the same bad partial and gets rejected again.

## The fix

Match the struct, and handle 416 (Range Not Satisfiable) alongside 404 — that's what a range request past the end of the object returns, which is the same situation:

```elixir
def handle_downloader_message({:error, %Mint.HTTPError{reason: {:http_error, status}}}, state)
    when status in [404, 416] do
```

## A second bug on the same path

`Updater` interpolated the raw downloader exit reason into its debug log:

```elixir
Logger.debug("[#{log_prefix()}] Downloader exited with reason \"#{reason}\"")
```

For a non-string reason such as `{:http_error, 404}` that raises `Protocol.UndefinedError`, so the updater crashed instead of stopping with `{:shutdown, {:download_error, reason}}` — the reason `UpdateManager` matches to report "Download failed" to Hub. The crash fell through to the catch-all clause and reported "Unexpected error" instead. Now uses `inspect/1`.

It's a `Logger.debug`, so it only bites when debug logging is enabled, but it's on exactly this path.