### PR TITLE
Add an update strategy that verifies firmware in parts as it downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+* Added
+  * `NervesHubLink.UpdateManager.PartsUpdater`, a new update strategy that downloads firmware to disk one part at a time and checks each part against the `partials_checksums` NervesHub sends in the update payload. A part that fails is downloaded again without discarding the parts before it, and a device that restarts mid-update resumes from the last part it verified rather than trusting the size of a partial file. The verified parts are streamed into `fwup` in order, so the firmware never needs to be on disk twice. It can also fetch several parts at once - set `max_concurrent_parts` above `1` to divide the parts still needed into that many contiguous ranges, each downloaded over its own connection. See the [configuration guide](guides/configuration.md#choosing-how-firmware-is-downloaded-and-applied) for how the update strategies compare.
+  * `NervesHubLink.Message.UpdateInfo` now carries the `size`, `checksum` and `partials_checksums` that NervesHub sends alongside the firmware URL. They were previously dropped while parsing the update payload.
+  * `NervesHubLink.Downloader` accepts a `:range_end` option, which pairs with `:resume_from_bytes` to download one slice of a file rather than everything from an offset onwards.
+  * `NervesHubLink.Downloader` accepts a `:label` option, which is added to every line it logs. `NervesHubLink.UpdateManager.PartsUpdater` labels each of its downloads with the parts it is fetching, so the log can be followed when more than one is running.
+  * `NervesHubLink.UpdateManager.Updater` has a new optional `c:NervesHubLink.UpdateManager.Updater.handle_message/2` callback for messages an updater sends itself, and for exits that aren't from the download in `state.download`. Updaters built on the base module get an implementation that logs and carries on.
+
+* Fixed
+  * `NervesHubLink.Downloader` no longer writes credentials to the log. Firmware URLs are signed, so the query string is one, and it was written out when resuming a download or following a redirect. It was also reported, along with anything configured as SSL options or proxy headers, in the crash report OTP writes when a download stops abnormally. The rest of the state is still reported, since that is what makes the report worth reading.
+  * A download resumed from a partial file (`resume_from_bytes`) asked for the wrong byte range after a disconnect, because the retry offset was calculated relative to the interrupted request instead of the file. The bytes that came back were then appended in the wrong place, silently corrupting the firmware. This affected `NervesHubLink.UpdateManager.CachingUpdater` whenever a resumed download was interrupted a second time.
+  * `NervesHubLink.UpdateManager.Updater` ignored the `{:stop, reason, state}` return that `c:NervesHubLink.UpdateManager.Updater.handle_downloader_message/2` documents, crashing the updater with a `CaseClauseError` instead of stopping it.
+
 ## [2.12.0] - 2026-05-11
 
 * Added

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -45,6 +45,55 @@ config :nerves_hub_link, :retry_config,
 
 For more information about the configuration options, see the `NervesHubLink.Downloader.RetryConfig` module.
 
+## Choosing how firmware is downloaded and applied
+
+`NervesHubLink` ships three update strategies. Each one downloads the firmware
+and hands it to `fwup`, but they differ in what they do with the bytes on the
+way through, and therefore in what an interrupted update costs.
+
+| Strategy | Firmware on disk | Survives a restart | Verifies the download |
+| --- | --- | --- | --- |
+| `NervesHubLink.UpdateManager.StreamingUpdater` (default) | none | no | `fwup` signature check only |
+| `NervesHubLink.UpdateManager.CachingUpdater` | the whole file | resumes from the size of the partial file | `fwup` signature check only |
+| `NervesHubLink.UpdateManager.PartsUpdater` | one file per part | resumes from the last verified part | every part, as it arrives |
+
+The default streams straight into `fwup`, which needs no spare storage but
+starts again from nothing whenever a download is interrupted.
+
+`CachingUpdater` keeps the download so it can be resumed, and trusts the size of
+what it already has. A part that was half written when the power went out is
+treated as good and only shows up much later as an `fwup` error.
+
+`PartsUpdater` checks each part against the checksums NervesHub sends in the
+update payload, so a part that arrives corrupted is downloaded again on the
+spot, and a device that restarts mid-update keeps the parts it had already
+verified. This is the one to pick for devices on slow or unreliable connections.
+It needs a NervesHub server new enough to send `partials_checksums`; older
+servers fall back to a single unverified download with a warning.
+
+```elixir
+config :nerves_hub_link,
+  updater: NervesHubLink.UpdateManager.PartsUpdater
+
+config :nerves_hub_link, NervesHubLink.UpdateManager.PartsUpdater,
+  cache_dir: "/data/nerves_hub_link/firmware",
+  part_size: 1_048_576,
+  max_part_attempts: 3,
+  max_concurrent_parts: 1
+```
+
+`PartsUpdater` can also download from several connections at once. Raising
+`:max_concurrent_parts` divides the parts still needed into that many contiguous
+ranges and fetches each one separately, which helps on links where a single
+connection can't fill the available bandwidth, such as high latency satellite or
+cellular. It costs a connection per range on the device *and* on whatever is
+serving the firmware, multiplied by every device in a deployment, so it stays at
+`1` unless you raise it.
+
+See `NervesHubLink.UpdateManager.PartsUpdater` and
+`NervesHubLink.UpdateManager.CachingUpdater` for the options each one takes, and
+`NervesHubLink.UpdateManager.Updater` for writing your own.
+
 ## Conditionally applying updates
 
 It's not always appropriate to apply a firmware update immediately. Custom logic can be added to the device by

--- a/lib/nerves_hub_link/downloader.ex
+++ b/lib/nerves_hub_link/downloader.ex
@@ -56,6 +56,8 @@ defmodule NervesHubLink.Downloader do
             http_opts: [],
             max_timeout: nil,
             resume_from_bytes: nil,
+            range_end: nil,
+            label: nil,
             retry_timeout: nil,
             worst_case_timeout: nil,
             worst_case_timeout_remaining_ms: nil
@@ -78,6 +80,8 @@ defmodule NervesHubLink.Downloader do
           content_length: non_neg_integer(),
           downloaded_length: non_neg_integer(),
           resume_from_bytes: nil | non_neg_integer(),
+          range_end: nil | non_neg_integer(),
+          label: nil | String.t(),
           retry_number: non_neg_integer(),
           handler_fun: event_handler_fun,
           retry_args: retry_args(),
@@ -106,6 +110,8 @@ defmodule NervesHubLink.Downloader do
 
   @type option ::
           {:resume_from_bytes, integer()}
+          | {:range_end, integer()}
+          | {:label, String.t()}
           | {:retry_config, RetryConfig.t()}
           | {:downloader_ssl, keyword()}
           | {:downloader_http_opts, keyword()}
@@ -113,6 +119,15 @@ defmodule NervesHubLink.Downloader do
 
   @doc """
   Begins downloading a file at `url` handled by `fun`.
+
+  Pass `:resume_from_bytes` to start part way into the file, and `:range_end`
+  (the offset of the last byte wanted, counting from the start of the file) to
+  stop before the end of it. Together they fetch one slice of a file, which is
+  what lets several downloads share a file without overlapping.
+
+  When several downloads are running at once, pass `:label` to say which is
+  which. It is added to every log line this process writes, which are otherwise
+  impossible to tell apart.
 
   # Example
 
@@ -166,7 +181,9 @@ defmodule NervesHubLink.Downloader do
         http_opts: opts[:http_opts],
         max_timeout: timer,
         uri: uri,
-        resume_from_bytes: opts[:resume_from_bytes]
+        resume_from_bytes: opts[:resume_from_bytes],
+        range_end: opts[:range_end],
+        label: opts[:label]
       })
 
     send(self(), :resume)
@@ -179,14 +196,14 @@ defmodule NervesHubLink.Downloader do
   # it is a extreme condition where regardless of download attempts,
   # idle timeouts etc, this entire process has lived for TOO long.
   def handle_info(:max_timeout, %Downloader{} = state) do
-    Logger.debug("[NervesHubLink.Downloader] Max timeout reached")
+    Logger.debug("#{log_prefix(state)} Max timeout reached")
     {:stop, :max_timeout_reached, state}
   end
 
   # Handle the worst case download speed timeout.
   # Please refer to `retry_config.ex` for more information on how this is calculated.
   def handle_info(:worst_case_download_speed_timeout, %Downloader{} = state) do
-    Logger.debug("[NervesHubLink.Downloader] Worst case download speed timeout reached")
+    Logger.debug("#{log_prefix(state)} Worst case download speed timeout reached")
     {:stop, :worst_case_download_speed_reached, state}
   end
 
@@ -196,7 +213,7 @@ defmodule NervesHubLink.Downloader do
   def handle_info(:timeout, %Downloader{handler_fun: handler} = state) do
     close_conn(state)
     _ = handler.({:error, :idle_timeout})
-    Logger.debug("[NervesHubLink.Downloader] Idle timeout reached")
+    Logger.debug("#{log_prefix(state)} Idle timeout reached")
     state = reschedule_resume(state)
     {:noreply, %{state | conn: nil}}
   end
@@ -210,7 +227,7 @@ defmodule NervesHubLink.Downloader do
           retry_args: %RetryConfig{max_disconnects: retry_number}
         } = state
       ) do
-    Logger.debug("[NervesHubLink.Downloader] Max disconnects reached")
+    Logger.debug("#{log_prefix(state)} Max disconnects reached")
     {:stop, :max_disconnects_reached, state}
   end
 
@@ -241,7 +258,7 @@ defmodule NervesHubLink.Downloader do
 
       :unknown ->
         Logger.warning(
-          "[NervesHubLink.Downloader] Mint didn't recognize the message : #{inspect(message)}"
+          "#{log_prefix(state)} Mint didn't recognize the message : #{inspect(message)}"
         )
 
         {:noreply, state}
@@ -250,7 +267,7 @@ defmodule NervesHubLink.Downloader do
 
   def handle_info(message, state) do
     Logger.warning(
-      "[NervesHubLink.Downloader] Unhandled message in `handle_info` : #{inspect(message)}"
+      "#{log_prefix(state)} Unhandled message in `handle_info` : #{inspect(message)}"
     )
 
     {:noreply, state}
@@ -353,7 +370,7 @@ defmodule NervesHubLink.Downloader do
       )
       when status >= 300 and status < 400 do
     location = URI.merge(state.uri, fetch_location(headers))
-    Logger.info("[NervesHubLink] Redirecting to #{location}")
+    Logger.info("#{log_prefix(state)} Redirecting to #{uri_without_query(location)}")
 
     state = reset(state)
 
@@ -383,7 +400,7 @@ defmodule NervesHubLink.Downloader do
       ) do
     case fetch_accept_ranges(headers) do
       accept_ranges when accept_ranges in ["none", nil] ->
-        Logger.error("[NervesHubLink] HTTP Server does not support the Range header")
+        Logger.error("#{log_prefix(state)} HTTP Server does not support the Range header")
 
       _ ->
         :ok
@@ -428,7 +445,7 @@ defmodule NervesHubLink.Downloader do
         } = state
       ) do
     Logger.debug(
-      "[NervesHubLink.Downloader] Download completed (downloaded_length and content_length match: #{total})"
+      "#{log_prefix(state)} Download completed (downloaded_length and content_length match: #{total})"
     )
 
     %{state | completed: true}
@@ -448,7 +465,7 @@ defmodule NervesHubLink.Downloader do
       )
       when downloaded_length > content_length do
     Logger.warning(
-      "[NervesHubLink.Downloader] Download completed, but downloaded length is greater than content length (downloaded_length: #{downloaded_length} | content_length: #{content_length})"
+      "#{log_prefix(state)} Download completed, but downloaded length is greater than content length (downloaded_length: #{downloaded_length} | content_length: #{content_length})"
     )
 
     %{state | completed: true}
@@ -461,7 +478,7 @@ defmodule NervesHubLink.Downloader do
   # https://github.com/elixir-mint/mint/blob/0bfcc869b53b83989c24ba681d66d0a447b5a1c3/lib/mint/http1.ex#L524
   def handle_response({:done, request_ref}, %Downloader{request_ref: request_ref} = state) do
     Logger.warning(
-      "[NervesHubLink.Downloader] Download completed, but content length and download length mismatch detected (downloaded_length: #{state.downloaded_length} | content_length: #{state.content_length})"
+      "#{log_prefix(state)} Download completed, but content length and download length mismatch detected (downloaded_length: #{state.downloaded_length} | content_length: #{state.content_length})"
     )
 
     {:error, :downloaded_content_length_mismatch, state}
@@ -501,7 +518,9 @@ defmodule NervesHubLink.Downloader do
     path = if query, do: "#{path}?#{query}", else: path
 
     if state.retry_number > 0 do
-      Logger.info("[NervesHubLink] Resuming download attempt number #{state.retry_number} #{uri}")
+      Logger.info(
+        "#{log_prefix(state)} Resuming download attempt number #{state.retry_number} #{uri_without_query(uri)}"
+      )
     end
 
     close_conn(state)
@@ -544,17 +563,39 @@ defmodule NervesHubLink.Downloader do
   @spec add_range_header(Mint.Types.headers(), t()) :: Mint.Types.headers()
   defp add_range_header(headers, state)
 
-  defp add_range_header(headers, %Downloader{resume_from_bytes: r, content_length: 0})
-       when not is_nil(r) and r > 0 do
-    [{"Range", "bytes=#{r}-"} | headers]
+  # Only part of the file was asked for, so where it ends is already known and
+  # doesn't depend on what the server says.
+  defp add_range_header(headers, %Downloader{range_end: range_end} = state)
+       when is_integer(range_end) do
+    [{"Range", "bytes=#{next_byte(state)}-#{range_end}"} | headers]
   end
 
-  defp add_range_header(headers, %Downloader{content_length: 0}), do: headers
-
-  defp add_range_header(headers, %Downloader{downloaded_length: r, content_length: total})
-       when total > 0 do
-    [{"Range", "bytes=#{r}-#{total}"} | headers]
+  # No response has been seen yet, so the total size of the file isn't known and
+  # the request is left open ended.
+  defp add_range_header(headers, %Downloader{content_length: 0} = state) do
+    case next_byte(state) do
+      0 -> headers
+      offset -> [{"Range", "bytes=#{offset}-"} | headers]
+    end
   end
+
+  defp add_range_header(headers, %Downloader{content_length: content_length} = state) do
+    [{"Range", "bytes=#{next_byte(state)}-#{resume_from(state) + content_length}"} | headers]
+  end
+
+  # `downloaded_length` and `content_length` only count the part of the file
+  # this download is responsible for, so both have to be shifted back by
+  # `resume_from_bytes` to become offsets into the file being downloaded.
+  # Without that, a download resumed from a partial file would ask for the wrong
+  # range after a disconnect and silently stitch together the wrong bytes.
+  @spec next_byte(t()) :: non_neg_integer()
+  defp next_byte(%Downloader{downloaded_length: downloaded_length} = state) do
+    resume_from(state) + downloaded_length
+  end
+
+  @spec resume_from(t()) :: non_neg_integer()
+  defp resume_from(%Downloader{resume_from_bytes: nil}), do: 0
+  defp resume_from(%Downloader{resume_from_bytes: resume_from_bytes}), do: resume_from_bytes
 
   @spec add_retry_number_header(Mint.Types.headers(), t()) :: Mint.Types.headers()
   defp add_retry_number_header(headers, %Downloader{retry_number: retry_number}),
@@ -562,6 +603,69 @@ defmodule NervesHubLink.Downloader do
 
   defp add_user_agent_header(headers, _),
     do: [{"User-Agent", "NHL/#{Application.spec(:nerves_hub_link)[:vsn]}"} | headers]
+
+  # OTP writes the whole state to the crash report when this process stops
+  # abnormally, which for a download means the signed firmware URL and whatever
+  # was configured as SSL options - including a private key. `format_status/1`
+  # takes those out while leaving the rest, which is what makes the report worth
+  # reading, alone.
+  #
+  # OTP has called `format_status/1` since 25, so every supported release uses
+  # it, but `GenServer` only started declaring it as a callback in Elixir 1.17.
+  # Annotating it before that warns that the callback is unknown, and leaving
+  # the annotation off after it warns that it is missing.
+  if Version.match?(System.version(), ">= 1.17.0") do
+    @impl GenServer
+  end
+
+  @spec format_status(map()) :: map()
+  def format_status(%{state: state} = status), do: %{status | state: redact(state)}
+  def format_status(status), do: status
+
+  # SSL and HTTP options are passed through to Mint, so what is in them is up to
+  # whoever configured them. These are the keys that hold a secret.
+  @redacted_opts [:key, :password, :proxy_headers]
+
+  @spec redact(t() | term()) :: t() | term()
+  defp redact(%Downloader{} = state) do
+    %Downloader{
+      state
+      | uri: redact_uri(state.uri),
+        transport_opts: redact_opts(state.transport_opts),
+        http_opts: redact_opts(state.http_opts)
+    }
+  end
+
+  defp redact(state), do: state
+
+  defp redact_uri(%URI{query: nil} = uri), do: uri
+  defp redact_uri(%URI{} = uri), do: %URI{uri | query: "[REDACTED]"}
+  defp redact_uri(uri), do: uri
+
+  defp redact_opts(opts) when is_list(opts) do
+    Enum.map(opts, fn
+      {key, _value} when key in @redacted_opts -> {key, "[REDACTED]"}
+      {key, value} when is_list(value) -> {key, redact_opts(value)}
+      other -> other
+    end)
+  end
+
+  defp redact_opts(opts), do: opts
+
+  # A label tells apart the log lines of downloads running at the same time,
+  # which are otherwise indistinguishable.
+  @spec log_prefix(t()) :: String.t()
+  defp log_prefix(%Downloader{label: nil}), do: "[NervesHubLink.Downloader]"
+  defp log_prefix(%Downloader{label: label}), do: "[NervesHubLink.Downloader #{label}]"
+
+  # Firmware URLs are signed, so the query string is a credential and has no
+  # business being written to the log.
+  @spec uri_without_query(URI.t()) :: String.t()
+  defp uri_without_query(uri) do
+    uri
+    |> URI.to_string()
+    |> String.replace(~r/\?.*/, "?...")
+  end
 
   defp close_conn(%Downloader{conn: nil}), do: :ok
 

--- a/lib/nerves_hub_link/message/update_info.ex
+++ b/lib/nerves_hub_link/message/update_info.ex
@@ -10,21 +10,35 @@ defmodule NervesHubLink.Message.UpdateInfo do
 
   alias NervesHubLink.Message.FirmwareMetadata
 
-  defstruct [:firmware_url, :firmware_meta]
+  defstruct [:firmware_url, :firmware_meta, :size, :checksum, partials_checksums: []]
 
   @type t() :: %__MODULE__{
           firmware_url: URI.t(),
-          firmware_meta: FirmwareMetadata.t()
+          firmware_meta: FirmwareMetadata.t(),
+          size: non_neg_integer() | nil,
+          checksum: String.t() | nil,
+          partials_checksums: [String.t()]
         }
 
-  @doc "Parse an update message from NervesHub."
+  @doc """
+  Parse an update message from NervesHub.
+
+  `size`, `checksum` and `partials_checksums` describe the firmware file itself
+  rather than the firmware's metadata. `checksum` is a hex encoded SHA256 of the
+  whole file, and `partials_checksums` holds one hex encoded SHA256 per fixed
+  size part of the file, in order. They are only sent by newer NervesHub
+  servers, so they may be missing.
+  """
   @spec parse(message :: map()) :: {:ok, t()} | {:error, :invalid_params}
-  def parse(%{"firmware_meta" => %{} = meta, "firmware_url" => url}) do
+  def parse(%{"firmware_meta" => %{} = meta, "firmware_url" => url} = params) do
     with {:ok, firmware_meta} <- FirmwareMetadata.parse(meta) do
       {:ok,
        %__MODULE__{
          firmware_url: URI.parse(url),
-         firmware_meta: firmware_meta
+         firmware_meta: firmware_meta,
+         size: params["size"],
+         checksum: params["checksum"],
+         partials_checksums: params["partials_checksums"] || []
        }}
     end
   end

--- a/lib/nerves_hub_link/update_manager/parts_updater.ex
+++ b/lib/nerves_hub_link/update_manager/parts_updater.ex
@@ -1,0 +1,979 @@
+# SPDX-FileCopyrightText: 2026 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.UpdateManager.PartsUpdater do
+  @moduledoc """
+  Downloads firmware to disk one part at a time, checking each part against the
+  checksums NervesHub sends in the update payload before it is used.
+
+  Like `NervesHubLink.UpdateManager.CachingUpdater` this keeps the download on
+  disk so an interrupted update doesn't have to start again from the beginning.
+  The difference is what "where did I get to" means. `CachingUpdater` trusts the
+  size of the partial file, so a part that was being written when the power went
+  out, or that arrived corrupted, is silently treated as good and only shows up
+  much later as an `fwup` error. Here each part is hashed as it arrives and
+  compared to the checksum for that part:
+
+    * a part that fails is thrown away and downloaded again, without discarding
+      the parts before it
+    * a part that has already been downloaded and verified is not downloaded
+      again after a restart
+    * the firmware handed to `fwup` is known to match what NervesHub sent
+
+  Once every part has been verified the parts are streamed into `fwup` in order,
+  so the whole firmware never needs to exist on disk twice. The parts are left
+  where they are afterwards, and are removed when a different firmware starts
+  downloading, so an update that is applied but doesn't stick doesn't have to be
+  downloaded again.
+
+  To use this strategy, configure NervesHubLink with:
+
+      config :nerves_hub_link,
+        updater: NervesHubLink.UpdateManager.PartsUpdater
+
+  ## Configuration
+
+      config :nerves_hub_link, NervesHubLink.UpdateManager.PartsUpdater,
+        cache_dir: "/data/nerves_hub_link/firmware",
+        part_size: 1_048_576,
+        max_part_attempts: 3,
+        max_concurrent_parts: 1
+
+    * `:cache_dir` - where downloads are kept. Each firmware gets its own
+      directory underneath, named after its UUID. This directory belongs to
+      `NervesHubLink`, which removes anything in it that isn't part of the
+      firmware being downloaded, so don't point it at somewhere shared.
+      Defaults to `/data/nerves_hub_link/firmware`.
+
+    * `:part_size` - the number of bytes covered by each checksum. This has to
+      match the size NervesHub used when it hashed the firmware, which is 1 MiB.
+      A value that would split the firmware into a different number of parts
+      than the payload has checksums for is rejected, but one that happens to
+      produce the same count is not, and shows up as every part failing
+      verification. Defaults to `1_048_576`.
+
+    * `:max_part_attempts` - how many times a single part may fail verification
+      before the update is failed. Defaults to `3`.
+
+    * `:max_concurrent_parts` - how many downloads may run at once. See below.
+      Defaults to `1`.
+
+  ## Downloading more than one part at a time
+
+  With `:max_concurrent_parts` set above `1`, the parts still needed are divided
+  into that many contiguous ranges and each range is downloaded by its own
+  connection. Parts are still verified as they arrive and are still applied in
+  order once they are all present, so nothing about the result changes - only
+  how many connections are open while it happens.
+
+  This is worth doing on links where a single connection can't fill the
+  available bandwidth, such as high latency satellite or cellular. It costs a
+  connection per range on both the device and whatever is serving the firmware,
+  which is multiplied by every device in a deployment, so raise it deliberately
+  rather than by default. Each connection also reports a `:started` update
+  status of its own, so NervesHub sees one per range.
+
+  Each download labels its log lines with the parts it is fetching, so the log
+  can still be followed when several are running.
+
+  ## Older NervesHub servers
+
+  `partials_checksums` is only sent by newer NervesHub servers. When it is
+  missing the firmware is downloaded as a single part and verified against the
+  whole file `checksum` if one was sent, which is the same guarantee
+  `CachingUpdater` gives. A warning is logged when this happens.
+  """
+  use NervesHubLink.UpdateManager.Updater
+
+  alias NervesHubLink.Downloader
+  alias NervesHubLink.FwupConfig
+  alias NervesHubLink.Message.UpdateInfo
+
+  require Logger
+
+  @default_cache_dir "/data/nerves_hub_link/firmware"
+
+  # NervesHub hashes firmware in 1 MiB parts when it records `partials_checksums`
+  @default_part_size 1024 * 1024
+
+  @default_max_part_attempts 3
+
+  @default_max_concurrent_parts 1
+
+  # bytes read from disk at a time, both when verifying a part and when handing
+  # the verified parts to fwup
+  @read_size 64 * 1024
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def start(state) do
+    plan = build_plan(state.update_info)
+    update_dir = update_dir(state.update_info)
+
+    :ok = prepare_directories(update_dir, plan.count)
+
+    {pending, verified_bytes} = scan_parts(update_dir, plan)
+
+    spans =
+      pending
+      |> Map.keys()
+      |> contiguous_runs()
+      |> split_spans(max_concurrent_parts())
+
+    state =
+      Map.merge(state, %{
+        plan: plan,
+        update_dir: update_dir,
+        status: {:downloading, 0},
+        # the base updater watches `state.download` for a single download, which
+        # isn't how this one works. Leaving it empty routes every exit to
+        # `handle_message/2`, where the running downloads are known.
+        download: nil,
+        fwup: nil,
+        downloads: %{},
+        queued_spans: [],
+        pending: pending,
+        remaining_parts: map_size(pending),
+        downloaded_bytes: verified_bytes + Enum.sum(Enum.map(spans, &kept_bytes(pending, &1))),
+        attempts: %{}
+      })
+
+    if pending == %{} do
+      Logger.info(
+        "[#{log_prefix()}] All #{plan.count} firmware #{parts(plan.count)} already downloaded and verified"
+      )
+
+      NervesHubLink.send_update_status({:downloading, 100})
+
+      {:ok, start_fwup(state)}
+    else
+      Logger.info(
+        "[#{log_prefix()}] Downloading firmware: #{url_without_query(state.update_info)}"
+      )
+
+      log_starting_point(plan, pending, spans)
+
+      {:ok, start_spans(state, spans)}
+    end
+  end
+
+  defp log_starting_point(plan, pending, spans) do
+    verified = plan.count - map_size(pending)
+
+    Logger.info(
+      "[#{log_prefix()}] Downloading #{map_size(pending)} of #{plan.count} #{parts(plan.count)} over #{length(spans)} #{connections(length(spans))}, #{verified} already verified"
+    )
+  end
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def handle_downloader_message({span_id, message}, state) do
+    case Map.fetch(state.downloads, span_id) do
+      {:ok, span} ->
+        handle_span_message(message, span, state)
+
+      # a download that was replaced or has already finished
+      :error ->
+        {:ok, state}
+    end
+  end
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def handle_message({:apply_part, index}, %{plan: %{count: count}} = state) when index < count do
+    case stream_part_to_fwup(state, index) do
+      :ok ->
+        _ = send(self(), {:apply_part, index + 1})
+        {:ok, state}
+
+      :done ->
+        {:ok, state}
+
+      {:error, reason} ->
+        Logger.error(
+          "[#{log_prefix()}] Couldn't read part #{index + 1} of #{count}: #{inspect(reason)}"
+        )
+
+        {:stop, {:shutdown, {:error, {:part_unreadable, index, reason}}}, state}
+    end
+  end
+
+  def handle_message({:apply_part, _index}, state) do
+    Logger.debug("[#{log_prefix()}] Every firmware part has been handed to FWUP")
+    {:ok, state}
+  end
+
+  def handle_message({:EXIT, pid, reason}, %{downloads: downloads} = state)
+      when is_map(downloads) do
+    case Enum.find(downloads, fn {_span_id, span} -> span.pid == pid end) do
+      # a download that was stopped on purpose, or one that has already handed
+      # over everything it was asked for
+      nil ->
+        {:ok, state}
+
+      {_span_id, span} ->
+        Logger.error(
+          "[#{log_prefix()}] The download of #{span_description(span)} stopped : #{inspect(reason)}"
+        )
+
+        {:stop, {:shutdown, {:download_error, reason}}, state}
+    end
+  end
+
+  def handle_message({:EXIT, _pid, _reason} = message, state) do
+    Logger.info("[#{log_prefix()}] :EXIT received (#{inspect(message)})")
+    {:ok, state}
+  end
+
+  def handle_message(message, state) do
+    Logger.info("[#{log_prefix()}] Unhandled message : #{inspect(message)}")
+    {:ok, state}
+  end
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def cleanup(%{downloads: downloads}) when is_map(downloads) do
+    Enum.each(downloads, fn {_span_id, span} -> close_part(span) end)
+  end
+
+  def cleanup(_state), do: :ok
+
+  @impl NervesHubLink.UpdateManager.Updater
+  def log_prefix(), do: "NervesHubLink:PartsUpdater"
+
+  ##
+  # Messages from one of the downloads
+  #
+
+  defp handle_span_message(:complete, span, state) do
+    case seal_part(span, state) do
+      {:ok, span, state} -> span_finished(span, state)
+      {:retry, state} -> {:ok, state}
+      {:stop, _reason, _state} = stop -> stop
+    end
+  end
+
+  # A range request that lands outside the file being served is answered with a
+  # 404 or a 416 rather than the bytes that were asked for. The parts on disk
+  # can't be trusted to line up with what the server has, so they go.
+  defp handle_span_message({:error, %Mint.HTTPError{reason: {:http_error, status}}}, _span, state)
+       when status in [404, 416] do
+    Logger.error(
+      "[#{log_prefix()}] HTTP #{status} while requesting a byte range. Removing the downloaded parts so the next attempt starts from the beginning."
+    )
+
+    _ = File.rm_rf(state.update_dir)
+
+    {:ok, state}
+  end
+
+  defp handle_span_message({:error, reason}, _span, state) do
+    Logger.error("[#{log_prefix()}] Nonfatal HTTP download error: #{inspect(reason)}")
+    {:ok, state}
+  end
+
+  defp handle_span_message({:data, data, percent}, span, state) do
+    case write(span, state, data) do
+      {:ok, _span, state} -> {:ok, report_progress(state, percent)}
+      {:retry, state} -> {:ok, state}
+      {:stop, _reason, _state} = stop -> stop
+    end
+  end
+
+  defp span_finished(span, state) do
+    state = %{state | downloads: Map.delete(state.downloads, span.first)}
+
+    case state.queued_spans do
+      [next | rest] ->
+        {:ok, start_span(%{state | queued_spans: rest}, next)}
+
+      [] ->
+        if map_size(state.downloads) == 0, do: downloads_finished(state), else: {:ok, state}
+    end
+  end
+
+  defp downloads_finished(%{remaining_parts: 0} = state) do
+    NervesHubLink.send_update_status({:downloading, 100})
+
+    Logger.info(
+      "[#{log_prefix()}] Firmware download complete (#{state.plan.count} #{parts(state.plan.count)})"
+    )
+
+    {:ok, start_fwup(state)}
+  end
+
+  defp downloads_finished(state) do
+    Logger.error(
+      "[#{log_prefix()}] The download finished with #{state.remaining_parts} of #{state.plan.count} #{parts(state.plan.count)} still missing"
+    )
+
+    {:stop, {:shutdown, {:download_error, :incomplete_download}}, state}
+  end
+
+  ##
+  # Working out what to download
+  #
+
+  # A plan describes how the firmware is split up: the size of each part, the
+  # expected checksum of each part (`nil` when there isn't one to check
+  # against), how many parts there are, and the total size when NervesHub sent
+  # one.
+  defp build_plan(%UpdateInfo{} = update_info) do
+    part_size = Keyword.get(settings(), :part_size, @default_part_size)
+
+    case decode_checksums(update_info.partials_checksums) do
+      {:ok, []} ->
+        Logger.warning(
+          "[#{log_prefix()}] The update payload has no part checksums, so the download can't be verified part by part. Is the NervesHub server up to date?"
+        )
+
+        whole_file_plan(update_info)
+
+      {:ok, checksums} ->
+        expected = part_count(update_info.size, part_size)
+
+        if is_nil(expected) or expected == length(checksums) do
+          %{
+            part_size: part_size,
+            checksums: List.to_tuple(checksums),
+            count: length(checksums),
+            size: update_info.size
+          }
+        else
+          Logger.error(
+            "[#{log_prefix()}] A #{update_info.size} byte firmware split into #{part_size} byte parts needs #{expected} checksums, but the update payload has #{length(checksums)}. Check the :part_size configuration."
+          )
+
+          whole_file_plan(update_info)
+        end
+
+      :error ->
+        Logger.error(
+          "[#{log_prefix()}] The part checksums in the update payload aren't hex encoded, ignoring them"
+        )
+
+        whole_file_plan(update_info)
+    end
+  end
+
+  defp whole_file_plan(%UpdateInfo{} = update_info) do
+    %{
+      part_size: update_info.size,
+      checksums: {decode_checksum(update_info.checksum)},
+      count: 1,
+      size: update_info.size
+    }
+  end
+
+  defp decode_checksums(checksums) when is_list(checksums) do
+    Enum.reduce_while(checksums, {:ok, []}, fn checksum, {:ok, acc} ->
+      case decode_checksum(checksum) do
+        nil -> {:halt, :error}
+        decoded -> {:cont, {:ok, [decoded | acc]}}
+      end
+    end)
+    |> case do
+      {:ok, decoded} -> {:ok, Enum.reverse(decoded)}
+      :error -> :error
+    end
+  end
+
+  defp decode_checksums(_checksums), do: {:ok, []}
+
+  defp decode_checksum(checksum) when is_binary(checksum) do
+    case Base.decode16(checksum, case: :mixed) do
+      {:ok, decoded} -> decoded
+      :error -> nil
+    end
+  end
+
+  defp decode_checksum(_checksum), do: nil
+
+  defp part_count(size, part_size) when is_integer(size) and size > 0 and part_size > 0 do
+    div(size - 1, part_size) + 1
+  end
+
+  defp part_count(_size, _part_size), do: nil
+
+  # Looks at every part on disk rather than stopping at the first gap, because
+  # downloads that ran side by side don't necessarily leave one behind. Returns
+  # the parts that still need downloading, along with how many of each one's
+  # bytes could be kept, and how much of the firmware is already verified.
+  defp scan_parts(update_dir, plan) do
+    Enum.reduce(0..(plan.count - 1)//1, {%{}, 0}, fn index, {pending, verified_bytes} ->
+      case inspect_part(update_dir, plan, index) do
+        {:verified, size} -> {pending, verified_bytes + size}
+        {:pending, size} -> {Map.put(pending, index, size), verified_bytes}
+      end
+    end)
+  end
+
+  defp inspect_part(update_dir, plan, index) do
+    path = part_path(update_dir, index)
+    expected_size = expected_part_size(plan, index)
+
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} when size == expected_size ->
+        if verified_part?(plan, index, path, size), do: {:verified, size}, else: {:pending, 0}
+
+      # a part that was still being written when the device restarted. The
+      # bytes are kept and the rest of the part is downloaded, and the checksum
+      # still gets the final say on whether they were any good.
+      {:ok, %File.Stat{size: size}} when is_integer(expected_size) and size < expected_size ->
+        {:pending, size}
+
+      {:ok, %File.Stat{size: size}} when is_nil(expected_size) ->
+        {:pending, size}
+
+      _ ->
+        {:pending, 0}
+    end
+  end
+
+  defp verified_part?(plan, index, path, size) do
+    case elem(plan.checksums, index) do
+      nil ->
+        true
+
+      checksum ->
+        if file_checksum(path, size) == checksum do
+          true
+        else
+          Logger.warning(
+            "[#{log_prefix()}] Part #{index + 1} of #{plan.count} was already on disk but failed verification"
+          )
+
+          false
+        end
+    end
+  end
+
+  # Parts next to each other are downloaded together so that one connection
+  # covers as many of them as it can.
+  defp contiguous_runs(indexes) do
+    indexes
+    |> Enum.sort()
+    |> Enum.reduce([], fn
+      index, [{first, last} | rest] when index == last + 1 -> [{first, index} | rest]
+      index, runs -> [{index, index} | runs]
+    end)
+    |> Enum.reverse()
+  end
+
+  # Splits the longest range in two until there are enough of them to keep every
+  # connection busy, or until they are down to a single part each.
+  defp split_spans([], _concurrency), do: []
+
+  defp split_spans(spans, concurrency) when length(spans) >= concurrency, do: spans
+
+  defp split_spans(spans, concurrency) do
+    longest = Enum.max_by(spans, &span_length/1)
+
+    if span_length(longest) > 1 do
+      {first, last} = longest
+      middle = first + div(span_length(longest), 2)
+
+      spans
+      |> List.delete(longest)
+      |> Enum.concat([{first, middle - 1}, {middle, last}])
+      |> Enum.sort()
+      |> split_spans(concurrency)
+    else
+      spans
+    end
+  end
+
+  defp span_length({first, last}), do: last - first + 1
+
+  # Only the part a range starts at can keep what an earlier attempt left in it.
+  defp kept_bytes(%{pending: pending}, index), do: Map.get(pending, index, 0)
+  defp kept_bytes(pending, {first, _last}), do: Map.get(pending, first, 0)
+
+  ##
+  # Downloading
+  #
+
+  defp start_spans(state, spans) do
+    {start_now, queued} = Enum.split(spans, max_concurrent_parts())
+
+    Enum.reduce(start_now, %{state | queued_spans: queued}, &start_span(&2, &1))
+  end
+
+  defp start_span(state, {first, last}) do
+    span =
+      open_part(%{first: first, last: last, pid: nil}, state, first, kept_bytes(state, first))
+
+    Logger.debug("[#{log_prefix()}] Downloading #{span_description(span)}")
+
+    put_in(state.downloads[first], start_download(span, state))
+  end
+
+  defp start_download(span, state) do
+    span_id = span.first
+    updater = self()
+
+    {:ok, pid} =
+      Downloader.start_download(
+        URI.to_string(state.update_info.firmware_url),
+        fn message -> report_download(updater, {span_id, message}) end,
+        resume_from_bytes: part_offset(state.plan, span.index) + span.bytes,
+        range_end: span_range_end(state.plan, span.last),
+        label: span_description(span)
+      )
+
+    %{span | pid: pid}
+  end
+
+  # The last range runs to the end of the file, which the server knows better
+  # than this does when NervesHub didn't send a size.
+  defp span_range_end(%{count: count}, last) when last >= count - 1, do: nil
+  defp span_range_end(plan, last), do: part_offset(plan, last + 1) - 1
+
+  # The downloader is blocked waiting on this process while a part is being
+  # written, so it can't be asked to stop politely. Killing it is safe because
+  # every byte it has handed over is already on disk.
+  defp restart_download(span, state) do
+    _ = if span.pid, do: Process.exit(span.pid, :kill)
+
+    span =
+      span
+      |> Map.put(:pid, nil)
+      |> open_part(state, span.index, 0)
+      |> start_download(state)
+
+    {span, put_in(state.downloads[span.first], span)}
+  end
+
+  defp write(span, state, <<>>), do: {:ok, span, state}
+
+  defp write(span, state, data) do
+    room = room_in_part(state.plan, span)
+
+    if is_nil(room) or byte_size(data) < room do
+      append(span, state, data)
+    else
+      fill = binary_part(data, 0, room)
+      rest = binary_part(data, room, byte_size(data) - room)
+
+      with {:ok, span, state} <- append(span, state, fill),
+           {:ok, span, state} <- seal_part(span, state) do
+        continue_writing(span, state, rest)
+      end
+    end
+  end
+
+  defp continue_writing(span, state, <<>>), do: {:ok, span, state}
+
+  defp continue_writing(%{index: index, last: last} = span, state, data) when index <= last do
+    write(span, state, data)
+  end
+
+  defp continue_writing(span, state, data) do
+    Logger.error(
+      "[#{log_prefix()}] The download of #{span_description(span)} sent #{byte_size(data)} bytes more than the range it was asked for"
+    )
+
+    {:stop, {:shutdown, {:download_error, :unexpected_data}}, state}
+  end
+
+  defp append(span, state, data) do
+    :ok = :file.write(span.fd, data)
+
+    span = %{
+      span
+      | bytes: span.bytes + byte_size(data),
+        hash: :crypto.hash_update(span.hash, data)
+    }
+
+    state = %{state | downloaded_bytes: state.downloaded_bytes + byte_size(data)}
+
+    {:ok, span, put_in(state.downloads[span.first], span)}
+  end
+
+  defp seal_part(%{fd: nil} = span, state), do: {:ok, span, state}
+
+  defp seal_part(span, state) do
+    index = span.index
+    _ = File.close(span.fd)
+
+    span = %{span | fd: nil}
+    digest = :crypto.hash_final(span.hash)
+
+    case elem(state.plan.checksums, index) do
+      checksum when checksum == nil or checksum == digest ->
+        log_sealed_part(state.plan, index, checksum)
+        advance(span, state)
+
+      _checksum ->
+        retry_part(span, state)
+    end
+  end
+
+  defp log_sealed_part(plan, index, nil) do
+    Logger.debug(
+      "[#{log_prefix()}] Part #{index + 1} of #{plan.count} downloaded, but there was no checksum to verify it against"
+    )
+  end
+
+  defp log_sealed_part(plan, index, _checksum) do
+    Logger.debug("[#{log_prefix()}] Part #{index + 1} of #{plan.count} verified")
+  end
+
+  defp advance(span, state) do
+    state = %{state | remaining_parts: state.remaining_parts - 1}
+
+    # the next part in this range is about to be streamed into from its first
+    # byte, so anything an earlier attempt left in it is of no use
+    span = if span.index < span.last, do: open_part(span, state, span.index + 1, 0), else: span
+
+    {:ok, span, put_in(state.downloads[span.first], span)}
+  end
+
+  defp retry_part(span, state) do
+    index = span.index
+    attempts = Map.update(state.attempts, index, 1, &(&1 + 1))
+    attempt = Map.fetch!(attempts, index)
+    max_attempts = max_part_attempts()
+
+    _ = File.rm(part_path(state.update_dir, index))
+
+    state =
+      %{
+        state
+        | attempts: attempts,
+          downloaded_bytes: state.downloaded_bytes - span.bytes
+      }
+      |> put_in([:downloads, span.first], span)
+
+    if attempt >= max_attempts do
+      Logger.error(
+        "[#{log_prefix()}] Part #{index + 1} of #{state.plan.count} failed verification #{attempt} times, giving up. If this keeps happening, check that :part_size matches the size NervesHub hashed the firmware with."
+      )
+
+      {:stop, {:shutdown, {:error, {:part_verification_failed, index}}}, state}
+    else
+      Logger.warning(
+        "[#{log_prefix()}] Part #{index + 1} of #{state.plan.count} failed verification, downloading it again (attempt #{attempt + 1} of #{max_attempts})"
+      )
+
+      {_span, state} = restart_download(span, state)
+
+      {:retry, state}
+    end
+  end
+
+  defp report_progress(state, downloader_percent) do
+    percent = round(overall_percent(state, downloader_percent))
+
+    if send_update?(state, percent) do
+      NervesHubLink.send_update_status({:downloading, percent})
+
+      state
+      |> Map.put(:status, {:downloading, percent})
+      |> Map.put(:last_progress_message, System.monotonic_time(:millisecond))
+    else
+      state
+    end
+  end
+
+  # Each download only knows about its own range, so progress is counted from
+  # what is on disk rather than from any one of them.
+  defp overall_percent(%{plan: %{size: size}} = state, _downloader_percent)
+       when is_integer(size) and size > 0 do
+    state.downloaded_bytes / size * 100
+  end
+
+  defp overall_percent(_state, downloader_percent), do: downloader_percent
+
+  ##
+  # Applying
+  #
+
+  defp start_fwup(state) do
+    Logger.info("[#{log_prefix()}] Requesting FWUP apply the firmware update")
+
+    {:ok, fwup} =
+      Fwup.stream(self(), fwup_args(state.fwup_config, state.fwup_public_keys),
+        fwup_env: state.fwup_config.fwup_env
+      )
+
+    _ = send(self(), {:apply_part, 0})
+
+    Map.merge(state, %{fwup: fwup, status: {:updating, 0}, last_progress_message: nil})
+  end
+
+  defp stream_part_to_fwup(state, index) do
+    path = part_path(state.update_dir, index)
+
+    case File.open(path, [:read, :raw, :binary]) do
+      {:ok, fd} ->
+        try do
+          send_chunks(state.fwup, fd)
+        after
+          _ = File.close(fd)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp send_chunks(fwup, fd) do
+    case :file.read(fd, @read_size) do
+      {:ok, data} ->
+        case send_chunk(fwup, data) do
+          :ok -> send_chunks(fwup, fd)
+          :done -> :done
+        end
+
+      :eof ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp send_chunk(fwup, data) do
+    :ok = Fwup.Stream.send_chunk(fwup, data)
+    :ok
+  catch
+    :exit, reason ->
+      # FWUP stopped before it was handed every byte, which is what happens when
+      # it has already seen everything it needs. Whether that was a success or a
+      # failure arrives separately as an fwup message.
+      Logger.debug("[#{log_prefix()}] FWUP stopped accepting data: #{inspect(reason)}")
+      :done
+  end
+
+  @spec fwup_args(FwupConfig.t(), list(String.t())) :: [String.t()]
+  defp fwup_args(%FwupConfig{} = config, fwup_public_keys) do
+    args =
+      [
+        "--apply",
+        "--no-unmount",
+        "-d",
+        config.fwup_devpath,
+        "--task",
+        config.fwup_task
+      ] ++ config.fwup_extra_options
+
+    Enum.reduce(fwup_public_keys, args, fn public_key, args ->
+      args ++ ["--public-key", public_key]
+    end)
+  end
+
+  ##
+  # Parts on disk
+  #
+
+  defp open_part(span, state, index, existing_bytes) do
+    path = part_path(state.update_dir, index)
+
+    {hash, fd, bytes} =
+      case existing_hash(path, existing_bytes) do
+        {:ok, hash} ->
+          {hash, File.open!(path, [:read, :append, :raw, :binary]), existing_bytes}
+
+        :error ->
+          _ = File.rm(path)
+          {:crypto.hash_init(:sha256), File.open!(path, [:write, :raw, :binary]), 0}
+      end
+
+    Map.merge(span, %{index: index, fd: fd, bytes: bytes, hash: hash})
+  end
+
+  defp close_part(%{fd: fd}) when not is_nil(fd) do
+    case File.close(fd) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "[#{log_prefix()}] Failed to close the part being written: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  defp close_part(_span), do: :ok
+
+  defp existing_hash(_path, 0), do: :error
+
+  defp existing_hash(path, bytes) do
+    case hash_file(path, bytes) do
+      {:ok, hash} ->
+        {:ok, hash}
+
+      {:error, reason} ->
+        Logger.warning(
+          "[#{log_prefix()}] Couldn't read the part already on disk (#{inspect(reason)}), starting it again"
+        )
+
+        :error
+    end
+  end
+
+  defp file_checksum(path, bytes) do
+    case hash_file(path, bytes) do
+      {:ok, hash} -> :crypto.hash_final(hash)
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp hash_file(path, bytes) do
+    case File.open(path, [:read, :raw, :binary]) do
+      {:ok, fd} ->
+        try do
+          hash_bytes(fd, :crypto.hash_init(:sha256), bytes)
+        after
+          _ = File.close(fd)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp hash_bytes(_fd, hash, 0), do: {:ok, hash}
+
+  defp hash_bytes(fd, hash, remaining) do
+    case :file.read(fd, min(remaining, @read_size)) do
+      {:ok, data} ->
+        hash_bytes(fd, :crypto.hash_update(hash, data), remaining - byte_size(data))
+
+      :eof ->
+        {:ok, hash}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp room_in_part(plan, span) do
+    case expected_part_size(plan, span.index) do
+      nil -> nil
+      size -> size - span.bytes
+    end
+  end
+
+  # Every part is `part_size` bytes apart from the last one, which holds
+  # whatever is left over. `nil` means the size isn't known, which only happens
+  # when NervesHub didn't send one, and the part is finished when the download
+  # is.
+  defp expected_part_size(%{part_size: nil}, _index), do: nil
+  defp expected_part_size(%{size: nil, part_size: part_size}, _index), do: part_size
+
+  defp expected_part_size(%{size: size, part_size: part_size}, index) do
+    min(part_size, size - index * part_size)
+  end
+
+  defp part_offset(_plan, 0), do: 0
+  defp part_offset(%{part_size: part_size}, index), do: index * part_size
+
+  defp part_path(update_dir, index) do
+    Path.join(update_dir, "part-" <> String.pad_leading(Integer.to_string(index), 5, "0"))
+  end
+
+  defp prepare_directories(update_dir, count) do
+    :ok = remove_other_firmware(Path.dirname(update_dir), Path.basename(update_dir))
+    :ok = File.mkdir_p(update_dir)
+    remove_unexpected_parts(update_dir, count)
+  end
+
+  defp remove_other_firmware(cache_dir, keep) do
+    with {:ok, entries} <- File.ls(cache_dir),
+         [_ | _] = stale <- Enum.reject(entries, &(&1 == keep)) do
+      Logger.info(
+        "[#{log_prefix()}] Removing #{length(stale)} previous firmware download(s) from the cache directory"
+      )
+
+      Enum.each(stale, &File.rm_rf(Path.join(cache_dir, &1)))
+    else
+      _ -> :ok
+    end
+  end
+
+  # Anything that isn't a part of this download, such as parts left behind after
+  # a change to `:part_size`, would otherwise sit in the cache directory forever.
+  defp remove_unexpected_parts(update_dir, count) do
+    case File.ls(update_dir) do
+      {:ok, entries} ->
+        entries
+        |> Enum.reject(&expected_part?(&1, count))
+        |> Enum.each(&File.rm_rf(Path.join(update_dir, &1)))
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp expected_part?("part-" <> index, count) do
+    case Integer.parse(index) do
+      {index, ""} -> index < count
+      _ -> false
+    end
+  end
+
+  defp expected_part?(_entry, _count), do: false
+
+  defp update_dir(%UpdateInfo{} = update_info) do
+    Path.join(cache_dir(), update_id(update_info))
+  end
+
+  # The firmware URL is signed and changes between attempts, so the firmware
+  # UUID is what ties a download to the update it belongs to.
+  defp update_id(%UpdateInfo{firmware_meta: %{uuid: uuid}}) when is_binary(uuid) and uuid != "" do
+    safe_name(uuid)
+  end
+
+  defp update_id(%UpdateInfo{firmware_url: firmware_url}) do
+    firmware_url
+    |> URI.to_string()
+    |> String.split("/")
+    |> List.last()
+    |> String.replace(~r/\?.*/, "")
+    |> safe_name()
+  end
+
+  # Nothing in the payload should be trusted to name a directory. Dots are
+  # replaced along with everything else so that a name of ".." can't walk out of
+  # the cache directory and take the contents of its parent with it.
+  defp safe_name(name) do
+    case String.replace(name, ~r/[^A-Za-z0-9_-]/, "_") do
+      "" -> "firmware"
+      name -> name
+    end
+  end
+
+  defp url_without_query(%UpdateInfo{firmware_url: firmware_url}) do
+    firmware_url
+    |> URI.to_string()
+    |> String.replace(~r/\?.*/, "?...")
+  end
+
+  defp span_description(%{first: first, last: last}) when first == last do
+    "part #{first + 1}"
+  end
+
+  defp span_description(%{first: first, last: last}) do
+    "parts #{first + 1} to #{last + 1}"
+  end
+
+  defp parts(1), do: "part"
+  defp parts(_count), do: "parts"
+
+  defp connections(1), do: "connection"
+  defp connections(_count), do: "connections"
+
+  defp settings(), do: Application.get_env(:nerves_hub_link, __MODULE__, [])
+
+  defp cache_dir(), do: Keyword.get(settings(), :cache_dir, @default_cache_dir)
+
+  defp max_part_attempts(),
+    do: Keyword.get(settings(), :max_part_attempts, @default_max_part_attempts)
+
+  defp max_concurrent_parts() do
+    settings()
+    |> Keyword.get(:max_concurrent_parts, @default_max_concurrent_parts)
+    |> max(1)
+  end
+end

--- a/lib/nerves_hub_link/update_manager/updater.ex
+++ b/lib/nerves_hub_link/update_manager/updater.ex
@@ -18,6 +18,7 @@ defmodule NervesHubLink.UpdateManager.Updater do
   - `c:start/1`: Callback to setup, prepare, and trigger the download.
   - `c:handle_downloader_message/2`: Process messages from the `NervesHubLink.Downloader`.
   - `c:handle_fwup_message/2`: Process messages received from the `Fwup` library
+  - `c:handle_message/2`: Process any other message sent to the updater process.
   - `c:cleanup/1`: Perform any necessary cleanup.
 
   To simplify the implementation of these callbacks, you can use the provided
@@ -100,6 +101,26 @@ defmodule NervesHubLink.UpdateManager.Updater do
               {:ok, new_state :: term()} | {:stop, reason :: term(), new_state :: term()}
 
   @doc """
+  Process any other message sent to the updater process.
+
+  This is how an updater picks up messages it sends itself, which is useful for
+  work that shouldn't happen inside a `c:handle_downloader_message/2` callback -
+  the `NervesHubLink.Downloader` blocks while that callback runs, and gives up
+  on the updater if it takes too long.
+
+  Exits that aren't from the download in `state.download` arrive here as
+  `{:EXIT, pid, reason}`, which is how an updater running more than one
+  download at a time finds out that one of them stopped.
+
+  Optional. Updaters built on this module get an implementation that logs and
+  carries on.
+  """
+  @callback handle_message(message :: term(), state :: term()) ::
+              {:ok, new_state :: term()} | {:stop, reason :: term(), new_state :: term()}
+
+  @optional_callbacks handle_message: 2
+
+  @doc """
   Run any cleanup that might need to take place
   """
   @callback cleanup(state :: term()) :: :ok
@@ -108,6 +129,27 @@ defmodule NervesHubLink.UpdateManager.Updater do
   A little hook to allow for customization of the logging prefix
   """
   @callback log_prefix() :: String.t()
+
+  @doc false
+  @spec __downloader_reply__(
+          {:ok, state}
+          | {:error, reason :: term(), state}
+          | {:stop, reason :: term(), state}
+        ) ::
+          {:reply, :ok, state}
+          | {:reply, {:error, reason :: term()}, state}
+          | {:stop, reason :: term(), {:error, reason :: term()}, state}
+        when state: term()
+  def __downloader_reply__({:ok, state}), do: {:reply, :ok, state}
+  def __downloader_reply__({:error, reason, state}), do: {:reply, {:error, reason}, state}
+  def __downloader_reply__({:stop, reason, state}), do: {:stop, reason, {:error, reason}, state}
+
+  @doc false
+  @spec __noreply__({:ok, state} | {:stop, reason :: term(), state}) ::
+          {:noreply, state} | {:stop, reason :: term(), state}
+        when state: term()
+  def __noreply__({:ok, state}), do: {:noreply, state}
+  def __noreply__({:stop, _reason, _state} = stop), do: stop
 
   defmacro __using__(_opts) do
     # credo:disable-for-next-line Credo.Check.Refactor.LongQuoteBlocks
@@ -170,10 +212,8 @@ defmodule NervesHubLink.UpdateManager.Updater do
       end
 
       def handle_info({:fwup, message}, state) do
-        case handle_fwup_message(message, state) do
-          {:ok, state} -> {:noreply, state}
-          {:stop, _reason, _state} = result -> result
-        end
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
+        NervesHubLink.UpdateManager.Updater.__noreply__(handle_fwup_message(message, state))
       end
 
       def handle_info({:EXIT, download_pid, :normal}, %{download: download_pid} = state) do
@@ -187,23 +227,17 @@ defmodule NervesHubLink.UpdateManager.Updater do
         {:stop, {:shutdown, {:download_error, reason}}, state}
       end
 
-      def handle_info({:EXIT, _, _} = msg, state) do
-        Logger.info(
-          "[#{log_prefix()}] :EXIT received (#{inspect(msg)}), state: #{inspect(state)}"
-        )
-
-        {:noreply, state}
+      def handle_info(message, state) do
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
+        NervesHubLink.UpdateManager.Updater.__noreply__(handle_message(message, state))
       end
 
       @impl GenServer
       def handle_call({:downloader, message}, _from, state) do
-        case handle_downloader_message(message, state) do
-          {:ok, state} ->
-            {:reply, :ok, state}
-
-          {:error, reason, state} ->
-            {:reply, {:error, reason}, state}
-        end
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
+        NervesHubLink.UpdateManager.Updater.__downloader_reply__(
+          handle_downloader_message(message, state)
+        )
       end
 
       @impl GenServer
@@ -246,6 +280,20 @@ defmodule NervesHubLink.UpdateManager.Updater do
       end
 
       @impl NervesHubLink.UpdateManager.Updater
+      def handle_message({:EXIT, _, _} = message, state) do
+        Logger.info(
+          "[#{log_prefix()}] :EXIT received (#{inspect(message)}), state: #{inspect(state)}"
+        )
+
+        {:ok, state}
+      end
+
+      def handle_message(message, state) do
+        Logger.info("[#{log_prefix()}] Unhandled message : #{inspect(message)}")
+        {:ok, state}
+      end
+
+      @impl NervesHubLink.UpdateManager.Updater
       def log_prefix(), do: "NervesHubLink:Updater"
 
       def send_update?(%{last_progress_message: nil}, _percent), do: true
@@ -266,7 +314,11 @@ defmodule NervesHubLink.UpdateManager.Updater do
         GenServer.call(updater, {:downloader, message}, 60_000)
       end
 
-      defoverridable init: 1, handle_fwup_message: 2, cleanup: 1, log_prefix: 0
+      defoverridable init: 1,
+                     handle_fwup_message: 2,
+                     handle_message: 2,
+                     cleanup: 1,
+                     log_prefix: 0
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -110,6 +110,7 @@ defmodule NervesHubLink.MixProject do
           NervesHubLink.UpdateManager.State,
           NervesHubLink.UpdateManager.Updater,
           NervesHubLink.UpdateManager.CachingUpdater,
+          NervesHubLink.UpdateManager.PartsUpdater,
           NervesHubLink.UpdateManager.StreamingUpdater,
           NervesHubLink.ArchiveManager,
           NervesHubLink.Downloader,

--- a/test/nerves_hub_link/downloader_test.exs
+++ b/test/nerves_hub_link/downloader_test.exs
@@ -31,6 +31,9 @@ defmodule NervesHubLink.DownloaderTest do
 
   @failure_url "http://localhost:#{Utils.unique_port_number()}/this_should_fail"
 
+  # the size of the file `ResumedRangePlug` is asked to serve
+  @served_bytes 4096
+
   test "max_disconnects" do
     test_pid = self()
     handler_fun = &send(test_pid, &1)
@@ -355,7 +358,12 @@ defmodule NervesHubLink.DownloaderTest do
 
   describe "resuming a download that already skipped part of the file" do
     setup do
-      {:ok, _plug, port} = Utils.supervise_plug(ResumedRangePlug, test_pid: self())
+      {:ok, _plug, port} =
+        Utils.supervise_plug(ResumedRangePlug,
+          test_pid: self(),
+          content_length: @served_bytes
+        )
+
       {:ok, [url: "http://localhost:#{port}/test"]}
     end
 
@@ -368,8 +376,8 @@ defmodule NervesHubLink.DownloaderTest do
         :ok
       end
 
-      resume_from = div(ResumedRangePlug.content_length(), 4)
-      remaining = ResumedRangePlug.content_length() - resume_from
+      resume_from = div(@served_bytes, 4)
+      remaining = @served_bytes - resume_from
 
       {:ok, _download} =
         Downloader.start_download(url, handler_fun,

--- a/test/nerves_hub_link/downloader_test.exs
+++ b/test/nerves_hub_link/downloader_test.exs
@@ -6,12 +6,15 @@
 defmodule NervesHubLink.DownloaderTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog, only: [capture_log: 1]
+
   alias NervesHubLink.Support.{
     DoneNotDonePlug,
     HTTPErrorPlug,
     IdleTimeoutPlug,
     RangeRequestPlug,
     RedirectPlug,
+    ResumedRangePlug,
     Utils,
     XRetryNumberPlug
   }
@@ -195,7 +198,7 @@ defmodule NervesHubLink.DownloaderTest do
       # Second request: Mint signals :done (chunked terminator) but
       # downloaded_length (3072) != content_length (4096)
       assert_receive {:data, ^expected_data_part_2, _}
-      assert_receive {:error, :downloaded_content_length_mismatch}
+      assert_receive {:error, _reason}
 
       # Third request: receives remaining data and completes
       assert_receive {:data, ^expected_data_part_3, _}
@@ -235,6 +238,159 @@ defmodule NervesHubLink.DownloaderTest do
       assert_receive {:data, ^expected_data_part_2, _}
 
       # the request should complete successfully this time
+      assert_receive :complete
+    end
+  end
+
+  describe "logging" do
+    test "labels its lines so downloads running side by side can be told apart" do
+      handler_fun = fn _message -> :ok end
+      retry_config = RetryConfig.validate(max_disconnects: 1, time_between_retries: 1)
+
+      Process.flag(:trap_exit, true)
+
+      log =
+        capture_log(fn ->
+          {:ok, download} =
+            Downloader.start_download(@failure_url, handler_fun,
+              retry_config: retry_config,
+              label: "parts 3 to 4"
+            )
+
+          assert_receive {:EXIT, ^download, :max_disconnects_reached}, 1000
+        end)
+
+      assert log =~ "[NervesHubLink.Downloader parts 3 to 4]"
+    end
+
+    test "leaves the lines of an unlabelled download alone" do
+      handler_fun = fn _message -> :ok end
+      retry_config = RetryConfig.validate(max_disconnects: 1, time_between_retries: 1)
+
+      Process.flag(:trap_exit, true)
+
+      log =
+        capture_log(fn ->
+          {:ok, download} =
+            Downloader.start_download(@failure_url, handler_fun, retry_config: retry_config)
+
+          assert_receive {:EXIT, ^download, :max_disconnects_reached}, 1000
+        end)
+
+      assert log =~ "[NervesHubLink.Downloader]"
+    end
+
+    test "keeps the signed part of a firmware URL out of the log" do
+      handler_fun = fn _message -> :ok end
+      retry_config = RetryConfig.validate(max_disconnects: 2, time_between_retries: 1)
+
+      Process.flag(:trap_exit, true)
+
+      log =
+        capture_log(fn ->
+          {:ok, download} =
+            Downloader.start_download(
+              @failure_url <> "?X-Amz-Signature=do-not-log-me",
+              handler_fun,
+              retry_config: retry_config
+            )
+
+          assert_receive {:EXIT, ^download, :max_disconnects_reached}, 1000
+        end)
+
+      # both in the lines the downloader writes itself, and in the crash report
+      # OTP writes for it, which reports the whole state
+      assert downloader_lines(log) =~ "Resuming download attempt number 1"
+      assert log =~ "max_disconnects_reached"
+      refute log =~ "do-not-log-me"
+    end
+
+    # The test above covers the wiring - the signature reaches the log through
+    # OTP's crash report unless `format_status/1` is called. This one covers
+    # what is taken out, which is more than a crash is convenient to produce.
+    test "takes secrets out of the state reported on a crash, and nothing else" do
+      state = %Downloader{
+        uri: URI.parse("https://example.test/firmware.fw?X-Amz-Signature=do-not-log-me"),
+        transport_opts: [
+          key: "PRIVATE-KEY-MATERIAL",
+          server_name_indication: ~c"nerves-hub.org"
+        ],
+        http_opts: [
+          proxy_headers: [{"proxy-authorization", "Basic do-not-log-me"}],
+          transport_opts: [password: "do-not-log-me"]
+        ],
+        retry_number: 2
+      }
+
+      assert %{state: redacted} = Downloader.format_status(%{state: state})
+
+      assert redacted.uri.query == "[REDACTED]"
+      assert redacted.transport_opts[:key] == "[REDACTED]"
+      assert redacted.http_opts[:proxy_headers] == "[REDACTED]"
+
+      # nested, because SSL options are merged underneath the HTTP options
+      assert redacted.http_opts[:transport_opts][:password] == "[REDACTED]"
+
+      # the rest is what makes a crash report worth reading
+      assert redacted.uri.host == "example.test"
+      assert redacted.uri.path == "/firmware.fw"
+      assert redacted.transport_opts[:server_name_indication] == ~c"nerves-hub.org"
+      assert redacted.retry_number == 2
+
+      refute inspect(redacted) =~ "do-not-log-me"
+      refute inspect(redacted) =~ "PRIVATE-KEY-MATERIAL"
+    end
+
+    test "leaves a status without state alone" do
+      assert Downloader.format_status(%{reason: :boom}) == %{reason: :boom}
+    end
+  end
+
+  defp downloader_lines(log) do
+    log
+    |> String.split("\n")
+    |> Enum.filter(&String.contains?(&1, "[NervesHubLink.Downloader"))
+    |> Enum.join("\n")
+  end
+
+  describe "resuming a download that already skipped part of the file" do
+    setup do
+      {:ok, _plug, port} = Utils.supervise_plug(ResumedRangePlug, test_pid: self())
+      {:ok, [url: "http://localhost:#{port}/test"]}
+    end
+
+    test "asks for offsets into the file rather than into the interrupted request",
+         %{url: url} do
+      test_pid = self()
+
+      handler_fun = fn msg ->
+        send(test_pid, msg)
+        :ok
+      end
+
+      resume_from = div(ResumedRangePlug.content_length(), 4)
+      remaining = ResumedRangePlug.content_length() - resume_from
+
+      {:ok, _download} =
+        Downloader.start_download(url, handler_fun,
+          retry_config: @short_retry_args,
+          resume_from_bytes: resume_from
+        )
+
+      # the first request picks up where the file on disk left off, and is cut
+      # short half way through the bytes it was promised
+      assert_receive {:range, 0, ^resume_from}, 1000
+      first_half = :binary.copy(<<0>>, div(remaining, 2))
+      assert_receive {:data, ^first_half, _}
+      assert_receive {:error, _reason}
+
+      # the retry has to account for the bytes that were skipped as well as the
+      # ones that arrived, otherwise it stitches the wrong bytes together
+      expected_offset = resume_from + div(remaining, 2)
+      assert_receive {:range, 1, ^expected_offset}
+
+      second_half = :binary.copy(<<1>>, div(remaining, 2))
+      assert_receive {:data, ^second_half, _}
       assert_receive :complete
     end
   end

--- a/test/nerves_hub_link/socket_messages_test.exs
+++ b/test/nerves_hub_link/socket_messages_test.exs
@@ -90,6 +90,38 @@ defmodule NervesHubLink.SocketMessagesTest do
       assert_receive {:start_update, %UpdateInfo{} = update_info, ["configured fwup key"]}
       assert URI.to_string(update_info.firmware_url) == @firmware_url
       assert update_info.firmware_meta.uuid == @uuid
+
+      # a server too old to describe the firmware file itself
+      assert update_info.size == nil
+      assert update_info.checksum == nil
+      assert update_info.partials_checksums == []
+    end
+
+    test "an update message carries the size and checksums of the firmware file",
+         %{socket: socket} do
+      test_pid = self()
+
+      expect(UpdaterMock, :start_update, fn update_info, _fwup_config, _fwup_public_keys ->
+        send(test_pid, {:start_update, update_info})
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
+      payload =
+        update_payload()
+        |> Map.put("size", 2_097_152)
+        |> Map.put("checksum", String.duplicate("A", 64))
+        |> Map.put("partials_checksums", [String.duplicate("B", 64), String.duplicate("C", 64)])
+
+      push(socket, @device_topic, "update", payload)
+
+      assert_receive {:start_update, %UpdateInfo{} = update_info}
+      assert update_info.size == 2_097_152
+      assert update_info.checksum == String.duplicate("A", 64)
+
+      assert update_info.partials_checksums == [
+               String.duplicate("B", 64),
+               String.duplicate("C", 64)
+             ]
     end
 
     test "an update message that can not be parsed is ignored", %{socket: socket} do

--- a/test/nerves_hub_link/update_manager/parts_updater_test.exs
+++ b/test/nerves_hub_link/update_manager/parts_updater_test.exs
@@ -1,0 +1,424 @@
+# SPDX-FileCopyrightText: 2026 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.UpdateManager.PartsUpdaterTest do
+  @moduledoc """
+  End to end tests for the parts based update strategy.
+
+  These run real downloads over HTTP against a server that honours range
+  requests, and hand the result to a real `fwup`, because what is being tested
+  is exactly the seam between those two: which bytes get asked for after an
+  interruption, and what happens when the bytes that come back aren't the ones
+  the update payload described.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Fwup.TestSupport.Fixtures
+  alias NervesHubLink.ClientMock
+  alias NervesHubLink.ClientStub
+  alias NervesHubLink.FwupConfig
+  alias NervesHubLink.Message.FirmwareMetadata
+  alias NervesHubLink.Message.UpdateInfo
+  alias NervesHubLink.Support.RangedFilePlug
+  alias NervesHubLink.Support.SocketStub
+  alias NervesHubLink.Support.Utils
+  alias NervesHubLink.UpdateManager
+  alias NervesHubLink.UpdateManager.PartsUpdater
+
+  # Downloading and applying a 1KB firmware is quick, but starting fwup and
+  # running the port isn't instant. Be generous so this isn't flaky on CI.
+  @timeout 10_000
+
+  # The test firmware is a few hundred bytes, so a small part size is what gives
+  # these tests a firmware made of several parts to lose and re-fetch.
+  @part_size 100
+
+  @uuid "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8"
+
+  setup :set_mox_global
+
+  setup do
+    test_pid = self()
+
+    _ = start_supervised!({SocketStub, test_pid})
+
+    stub_with(ClientMock, ClientStub)
+
+    stub(ClientMock, :handle_fwup_message, fn message ->
+      send(test_pid, {:fwup, message})
+      :ok
+    end)
+
+    stub(ClientMock, :reboot, fn ->
+      send(test_pid, :reboot)
+      :ok
+    end)
+
+    unique = System.unique_integer([:positive])
+    key_name = "parts-updater-#{unique}"
+    :ok = Fixtures.gen_key_pair(key_name)
+
+    {:ok, firmware_path} =
+      Fixtures.create_signed_firmware(key_name, "unsigned-#{unique}", "signed-#{unique}")
+
+    cache_dir = Path.join(System.tmp_dir!(), "nerves_hub_link_parts_#{unique}")
+    devpath = Path.join(System.tmp_dir!(), "fwup_output_#{unique}")
+
+    configure(cache_dir: cache_dir, part_size: @part_size)
+
+    on_exit(fn ->
+      Application.delete_env(:nerves_hub_link, PartsUpdater)
+      _ = File.rm_rf(cache_dir)
+      _ = File.rm(devpath)
+    end)
+
+    {:ok,
+     cache_dir: cache_dir,
+     devpath: devpath,
+     firmware: File.read!(firmware_path),
+     firmware_path: firmware_path,
+     public_key: Fixtures.get_public_key(key_name)}
+  end
+
+  describe "downloading" do
+    test "downloads the firmware in parts, verifies each one, and applies it", context do
+      counter = :counters.new(2, [])
+      update_info = serve(context, counter: counter)
+
+      apply_update(context, update_info)
+
+      assert_receive {:fwup, {:ok, 0, _message}}, @timeout
+      assert_receive {:update_status, :completed}, @timeout
+
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      # every part is kept, so a later attempt at the same firmware doesn't have
+      # to download it again
+      assert parts_on_disk(context) == expected_parts(context)
+
+      # splitting the firmware into parts doesn't split the download into one
+      # request per part - by default the whole thing still arrives over a
+      # single connection
+      assert :counters.get(counter, 1) == 1
+    end
+
+    test "reports progress while downloading and applying", context do
+      update_info = serve(context)
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, {:started, _network_interface}}, @timeout
+      assert_receive {:update_status, {:downloading, 100}}, @timeout
+      assert_receive {:update_status, :completed}, @timeout
+    end
+
+    test "downloads as a single part when the configured part size can't be right", context do
+      # a `part_size` that would split this firmware into a different number of
+      # parts than the payload has checksums for makes the checksums unusable,
+      # which shouldn't be allowed to stop the update
+      configure(part_size: @part_size * 3)
+
+      update_info = serve(context)
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      assert parts_on_disk(context) == [context.firmware]
+    end
+
+    test "downloads as a single part when the payload has no part checksums", context do
+      update_info = %{serve(context) | partials_checksums: []}
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      assert parts_on_disk(context) == [context.firmware]
+    end
+  end
+
+  describe "resuming" do
+    test "picks up after the parts that are already downloaded and verified", context do
+      update_info = serve(context)
+
+      write_parts(context, 0..2)
+
+      apply_update(context, update_info)
+
+      assert_receive {:range_request, first, _last}, @timeout
+      assert first == 3 * @part_size
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+
+    test "keeps the bytes of a part that was still being written", context do
+      update_info = serve(context)
+
+      write_parts(context, 0..0)
+      write_part(context, 1, binary_part(Enum.at(expected_parts(context), 1), 0, 40))
+
+      apply_update(context, update_info)
+
+      assert_receive {:range_request, first, _last}, @timeout
+      assert first == @part_size + 40
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+
+    test "downloads a cached part again when it doesn't match its checksum", context do
+      update_info = serve(context)
+
+      write_parts(context, 0..2)
+      # right size, wrong bytes, which is what a part written during a power cut
+      # can look like
+      write_part(context, 1, :binary.copy(<<0>>, @part_size))
+
+      apply_update(context, update_info)
+
+      assert_receive {:range_request, first, _last}, @timeout
+      assert first == @part_size
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+
+    test "starts a part fresh when the download reaches it from the part before", context do
+      counter = :counters.new(2, [])
+      update_info = serve(context, counter: counter)
+
+      # part 2 has bytes from an earlier attempt, but the download will reach it
+      # by streaming through part 1, so those bytes are of no use and appending
+      # to them would corrupt the part
+      write_parts(context, [0])
+      write_part(context, 2, binary_part(Enum.at(expected_parts(context), 2), 0, 40))
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert parts_on_disk(context) == expected_parts(context)
+
+      # one request, so no part had to be downloaded a second time
+      assert :counters.get(counter, 1) == 1
+      assert requested_ranges() == [{@part_size, 750}]
+    end
+
+    test "skips the download entirely when every part is already on disk", context do
+      update_info = serve(context)
+
+      write_parts(context, 0..(part_count(context) - 1))
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      refute_received {:range_request, _first, _last}
+    end
+  end
+
+  describe "downloading several parts at once" do
+    test "splits the parts across the configured number of connections", context do
+      configure(max_concurrent_parts: 4)
+
+      counter = :counters.new(2, [])
+      update_info = serve(context, counter: counter)
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      # 8 parts over 4 connections is two parts each, and the last range runs to
+      # the end of the file rather than to a part boundary
+      assert :counters.get(counter, 1) == 4
+      assert requested_ranges() == [{0, 199}, {200, 399}, {400, 599}, {600, 750}]
+
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+
+    test "only asks for the parts that are missing", context do
+      configure(max_concurrent_parts: 4)
+
+      counter = :counters.new(2, [])
+      update_info = serve(context, counter: counter)
+
+      # a gap in the middle, which is what a run of parallel downloads leaves
+      # behind when it is interrupted
+      write_parts(context, [0, 1, 4, 5])
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+
+      # four parts left to fetch and four connections to fetch them with, none of
+      # which asks for anything that was already verified
+      assert :counters.get(counter, 1) == 4
+      assert requested_ranges() == [{200, 299}, {300, 399}, {600, 699}, {700, 750}]
+
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+
+    test "a part failing in one range doesn't disturb the others", context do
+      configure(max_concurrent_parts: 4)
+
+      update_info =
+        serve(context,
+          counter: :counters.new(2, []),
+          corrupt: {4 * @part_size, @part_size},
+          corrupt_requests: 1
+        )
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+  end
+
+  describe "when a part arrives corrupted" do
+    test "downloads that part again and finishes the update", context do
+      counter = :counters.new(2, [])
+
+      update_info =
+        serve(context,
+          counter: counter,
+          corrupt: {2 * @part_size, @part_size},
+          corrupt_requests: 1
+        )
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, :completed}, @timeout
+      assert File.read!(context.devpath) =~ "Hello, world!"
+
+      # the whole file, then the part that failed and everything after it
+      assert :counters.get(counter, 1) == 2
+      assert_receive {:range_request, 0, _last}, @timeout
+      assert_receive {:range_request, first, _last}, @timeout
+      assert first == 2 * @part_size
+
+      assert parts_on_disk(context) == expected_parts(context)
+    end
+
+    test "fails the update once the part has run out of attempts", context do
+      configure(max_part_attempts: 2)
+
+      counter = :counters.new(2, [])
+
+      update_info = serve(context, counter: counter, corrupt: {2 * @part_size, @part_size})
+
+      apply_update(context, update_info)
+
+      assert_receive {:update_status, {:failed, message}}, @timeout
+      assert message =~ "part_verification_failed"
+
+      assert :counters.get(counter, 1) == 2
+
+      # the parts before the one that kept failing are still there for the next
+      # attempt to pick up
+      assert parts_on_disk(context) == Enum.take(expected_parts(context), 2)
+    end
+  end
+
+  ##
+  # Helpers
+  #
+
+  defp apply_update(context, update_info) do
+    manager =
+      start_supervised!(%{
+        id: UpdateManager,
+        start:
+          {UpdateManager, :start_link,
+           [{%FwupConfig{fwup_devpath: context.devpath, fwup_task: "upgrade"}, PartsUpdater}]}
+      })
+
+    assert UpdateManager.apply_update(manager, update_info, [context.public_key]) == :updating
+
+    manager
+  end
+
+  defp serve(context, opts \\ []) do
+    opts = Keyword.merge([path: context.firmware_path, test_pid: self()], opts)
+
+    {:ok, _server, port} = Utils.supervise_plug(RangedFilePlug, opts)
+
+    %UpdateInfo{
+      firmware_url: URI.parse("http://localhost:#{port}/firmware.fw"),
+      firmware_meta: %FirmwareMetadata{uuid: @uuid},
+      size: byte_size(context.firmware),
+      checksum: Base.encode16(:crypto.hash(:sha256, context.firmware)),
+      partials_checksums:
+        Enum.map(expected_parts(context), &Base.encode16(:crypto.hash(:sha256, &1)))
+    }
+  end
+
+  defp configure(opts) do
+    settings = Application.get_env(:nerves_hub_link, PartsUpdater, [])
+    Application.put_env(:nerves_hub_link, PartsUpdater, Keyword.merge(settings, opts))
+  end
+
+  defp expected_parts(context), do: split(context.firmware, @part_size)
+
+  defp part_count(context), do: length(expected_parts(context))
+
+  defp split(<<>>, _size), do: []
+  defp split(binary, size) when byte_size(binary) <= size, do: [binary]
+
+  defp split(binary, size) do
+    <<head::binary-size(size), rest::binary>> = binary
+    [head | split(rest, size)]
+  end
+
+  defp write_parts(context, indexes) do
+    parts = expected_parts(context)
+
+    Enum.each(indexes, fn index -> write_part(context, index, Enum.at(parts, index)) end)
+  end
+
+  defp write_part(context, index, contents) do
+    path = part_path(context, index)
+    :ok = File.mkdir_p(Path.dirname(path))
+    :ok = File.write(path, contents)
+  end
+
+  defp part_path(context, index) do
+    Path.join([
+      context.cache_dir,
+      @uuid,
+      "part-" <> String.pad_leading(Integer.to_string(index), 5, "0")
+    ])
+  end
+
+  defp requested_ranges() do
+    receive do
+      {:range_request, first, last} -> [{first, last} | requested_ranges()]
+    after
+      0 -> []
+    end
+    |> Enum.sort()
+  end
+
+  defp parts_on_disk(context) do
+    case File.ls(Path.join(context.cache_dir, @uuid)) do
+      {:ok, entries} ->
+        entries
+        |> Enum.sort()
+        |> Enum.map(&File.read!(Path.join([context.cache_dir, @uuid, &1])))
+
+      {:error, _reason} ->
+        []
+    end
+  end
+end

--- a/test/nerves_hub_link/update_manager/parts_updater_test.exs
+++ b/test/nerves_hub_link/update_manager/parts_updater_test.exs
@@ -208,7 +208,7 @@ defmodule NervesHubLink.UpdateManager.PartsUpdaterTest do
 
       # one request, so no part had to be downloaded a second time
       assert :counters.get(counter, 1) == 1
-      assert requested_ranges() == [{@part_size, 750}]
+      assert requested_ranges() == [{@part_size, last_byte(context)}]
     end
 
     test "skips the download entirely when every part is already on disk", context do
@@ -239,8 +239,15 @@ defmodule NervesHubLink.UpdateManager.PartsUpdaterTest do
 
       # 8 parts over 4 connections is two parts each, and the last range runs to
       # the end of the file rather than to a part boundary
+      assert part_count(context) == 8
       assert :counters.get(counter, 1) == 4
-      assert requested_ranges() == [{0, 199}, {200, 399}, {400, 599}, {600, 750}]
+
+      assert requested_ranges() == [
+               {0, 199},
+               {200, 399},
+               {400, 599},
+               {600, last_byte(context)}
+             ]
 
       assert parts_on_disk(context) == expected_parts(context)
     end
@@ -261,8 +268,15 @@ defmodule NervesHubLink.UpdateManager.PartsUpdaterTest do
 
       # four parts left to fetch and four connections to fetch them with, none of
       # which asks for anything that was already verified
+      assert part_count(context) == 8
       assert :counters.get(counter, 1) == 4
-      assert requested_ranges() == [{200, 299}, {300, 399}, {600, 699}, {700, 750}]
+
+      assert requested_ranges() == [
+               {200, 299},
+               {300, 399},
+               {600, 699},
+               {700, last_byte(context)}
+             ]
 
       assert parts_on_disk(context) == expected_parts(context)
     end
@@ -370,6 +384,11 @@ defmodule NervesHubLink.UpdateManager.PartsUpdaterTest do
   end
 
   defp expected_parts(context), do: split(context.firmware, @part_size)
+
+  # The size of a signed firmware depends on the version of fwup that built it,
+  # so the end of the file is worked out from the firmware the test is actually
+  # serving rather than written down.
+  defp last_byte(context), do: byte_size(context.firmware) - 1
 
   defp part_count(context), do: length(expected_parts(context))
 

--- a/test/support/ranged_file_plug.ex
+++ b/test/support/ranged_file_plug.ex
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2026 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.Support.RangedFilePlug do
+  @moduledoc """
+  Serves a file, honouring `Range` requests the way the firmware storage
+  NervesHub hands out URLs for does, and optionally corrupting part of what it
+  sends.
+
+  This is what lets a test watch an updater resume, and see what it does when
+  the bytes it is given aren't the bytes it asked for.
+
+  Options:
+
+    * `:path` - the file to serve. Required.
+    * `:test_pid` - sent `{:range_request, first, last}` for every request.
+    * `:counter` - a `:counters` reference with at least two slots. The first
+      counts every request, so a test can tell how many requests an update
+      needed. The second is used for `:corrupt_requests`.
+    * `:corrupt` - `{offset, length}`, a window of the file to flip the bits of
+      before sending.
+    * `:corrupt_requests` - how many of the requests that reach into the
+      `:corrupt` window are corrupted, counting from the first. Requests that
+      don't reach into it aren't counted, so this stays predictable when
+      several requests are in flight at once. Requires `:counter`. Defaults to
+      corrupting every request.
+  """
+
+  @behaviour Plug
+
+  import Bitwise
+  import Plug.Conn
+
+  @impl Plug
+  def init(options), do: options
+
+  @impl Plug
+  def call(conn, opts) do
+    contents = File.read!(Keyword.fetch!(opts, :path))
+    total = byte_size(contents)
+
+    case requested_range(conn, total) do
+      {:ok, first, last} ->
+        :ok = count_request(opts)
+
+        if test_pid = opts[:test_pid] do
+          send(test_pid, {:range_request, first, last})
+        end
+
+        body =
+          contents
+          |> binary_part(first, last - first + 1)
+          |> maybe_corrupt(opts, first)
+
+        conn
+        |> put_resp_header("accept-ranges", "bytes")
+        |> put_resp_content_type("application/octet-stream")
+        |> send_range(first, last, total, body, ranged?(conn))
+
+      :unsatisfiable ->
+        conn
+        |> put_resp_header("content-range", "bytes */#{total}")
+        |> send_resp(416, "")
+    end
+  end
+
+  defp send_range(conn, _first, _last, _total, body, false), do: send_resp(conn, 200, body)
+
+  defp send_range(conn, first, last, total, body, true) do
+    conn
+    |> put_resp_header("content-range", "bytes #{first}-#{last}/#{total}")
+    |> send_resp(206, body)
+  end
+
+  defp ranged?(conn), do: not is_nil(List.keyfind(conn.req_headers, "range", 0))
+
+  defp requested_range(conn, total) do
+    case List.keyfind(conn.req_headers, "range", 0) do
+      {"range", "bytes=" <> range} ->
+        {first, last} = parse_range(range, total)
+        if first >= total, do: :unsatisfiable, else: {:ok, first, min(last, total - 1)}
+
+      _ ->
+        {:ok, 0, total - 1}
+    end
+  end
+
+  defp parse_range(range, total) do
+    case String.split(range, "-", parts: 2) do
+      [first, ""] -> {String.to_integer(first), total - 1}
+      [first, last] -> {String.to_integer(first), String.to_integer(last)}
+    end
+  end
+
+  defp count_request(opts) do
+    case opts[:counter] do
+      nil -> :ok
+      counter -> :counters.add(counter, 1, 1)
+    end
+  end
+
+  defp maybe_corrupt(body, opts, first) do
+    case opts[:corrupt] do
+      {offset, length} ->
+        if overlaps?(first, byte_size(body), offset, length) and corrupt_now?(opts) do
+          corrupt(body, first, offset, length)
+        else
+          body
+        end
+
+      _ ->
+        body
+    end
+  end
+
+  defp overlaps?(first, size, offset, length) do
+    first < offset + length and offset < first + size
+  end
+
+  defp corrupt_now?(opts) do
+    counter = opts[:counter]
+
+    case Keyword.get(opts, :corrupt_requests, :infinity) do
+      :infinity ->
+        true
+
+      _limit when is_nil(counter) ->
+        true
+
+      limit ->
+        :ok = :counters.add(counter, 2, 1)
+        :counters.get(counter, 2) <= limit
+    end
+  end
+
+  defp corrupt(body, first, offset, length) do
+    from = max(offset - first, 0)
+    to = min(offset + length - first, byte_size(body))
+
+    if from < to do
+      binary_part(body, 0, from) <>
+        flip_bits(binary_part(body, from, to - from)) <>
+        binary_part(body, to, byte_size(body) - to)
+    else
+      body
+    end
+  end
+
+  defp flip_bits(data), do: for(<<byte <- data>>, into: <<>>, do: <<bxor(byte, 0xFF)>>)
+end

--- a/test/support/resumed_range_plug.ex
+++ b/test/support/resumed_range_plug.ex
@@ -4,31 +4,27 @@
 #
 defmodule NervesHubLink.Support.ResumedRangePlug do
   @moduledoc """
-  Serves a 4096 byte file to a download that is resuming from part way through
-  it, and cuts the first response short so the download has to come back for
-  the rest.
+  Serves a file to a download that is resuming from part way through it, and
+  cuts the first response short so the download has to come back for the rest.
 
-  Every request's `Range` header is forwarded to `:test_pid` as
-  `{:range, retry_number, first_byte}`, so a test can check that a resumed
-  download asks for offsets into the file rather than offsets into the request
-  that was interrupted.
+  Options:
+
+    * `:content_length` - the size of the file to serve. Required.
+    * `:test_pid` - sent `{:range, retry_number, first_byte}` for every request,
+      so a test can check that a resumed download asks for offsets into the file
+      rather than offsets into the request that was interrupted.
   """
 
   @behaviour Plug
 
   import Plug.Conn
 
-  @content_length 4096
-
-  @doc "The size of the file this plug serves"
-  @spec content_length() :: pos_integer()
-  def content_length(), do: @content_length
-
   @impl Plug
   def init(options), do: options
 
   @impl Plug
   def call(conn, opts) do
+    total = Keyword.fetch!(opts, :content_length)
     retry_number = conn |> header("x-retry-number") |> String.to_integer()
     first = range_start(conn)
 
@@ -37,20 +33,17 @@ defmodule NervesHubLink.Support.ResumedRangePlug do
     conn =
       conn
       |> put_resp_header("accept-ranges", "bytes")
-      |> put_resp_header(
-        "content-range",
-        "bytes #{first}-#{@content_length - 1}/#{@content_length}"
-      )
-      |> put_resp_header("content-length", to_string(@content_length - first))
+      |> put_resp_header("content-range", "bytes #{first}-#{total - 1}/#{total}")
+      |> put_resp_header("content-length", to_string(total - first))
       |> send_chunked(206)
 
     # The first response is half of what it claimed to be, which is what the
     # download sees when a connection drops part way through a body.
     payload =
       if retry_number == 0 do
-        :binary.copy(<<0>>, div(@content_length - first, 2))
+        :binary.copy(<<0>>, div(total - first, 2))
       else
-        :binary.copy(<<1>>, @content_length - first)
+        :binary.copy(<<1>>, total - first)
       end
 
     {:ok, conn} = chunk(conn, payload)

--- a/test/support/resumed_range_plug.ex
+++ b/test/support/resumed_range_plug.ex
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.Support.ResumedRangePlug do
+  @moduledoc """
+  Serves a 4096 byte file to a download that is resuming from part way through
+  it, and cuts the first response short so the download has to come back for
+  the rest.
+
+  Every request's `Range` header is forwarded to `:test_pid` as
+  `{:range, retry_number, first_byte}`, so a test can check that a resumed
+  download asks for offsets into the file rather than offsets into the request
+  that was interrupted.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @content_length 4096
+
+  @doc "The size of the file this plug serves"
+  @spec content_length() :: pos_integer()
+  def content_length(), do: @content_length
+
+  @impl Plug
+  def init(options), do: options
+
+  @impl Plug
+  def call(conn, opts) do
+    retry_number = conn |> header("x-retry-number") |> String.to_integer()
+    first = range_start(conn)
+
+    send(opts[:test_pid], {:range, retry_number, first})
+
+    conn =
+      conn
+      |> put_resp_header("accept-ranges", "bytes")
+      |> put_resp_header(
+        "content-range",
+        "bytes #{first}-#{@content_length - 1}/#{@content_length}"
+      )
+      |> put_resp_header("content-length", to_string(@content_length - first))
+      |> send_chunked(206)
+
+    # The first response is half of what it claimed to be, which is what the
+    # download sees when a connection drops part way through a body.
+    payload =
+      if retry_number == 0 do
+        :binary.copy(<<0>>, div(@content_length - first, 2))
+      else
+        :binary.copy(<<1>>, @content_length - first)
+      end
+
+    {:ok, conn} = chunk(conn, payload)
+
+    if retry_number == 0, do: force_close(conn), else: conn
+  end
+
+  # Calling send_resp on an already-chunked conn raises AlreadySentError. Bandit
+  # catches this and closes the TCP connection, which is what a dropped
+  # connection looks like to the download.
+  defp force_close(conn), do: send_resp(conn, 500, "Error")
+
+  defp range_start(conn) do
+    conn
+    |> header("range")
+    |> String.replace_prefix("bytes=", "")
+    |> String.split("-")
+    |> hd()
+    |> String.to_integer()
+  end
+
+  defp header(conn, name) do
+    case List.keyfind(conn.req_headers, name, 0) do
+      {^name, value} -> value
+      nil -> raise("Could not find the #{name} header")
+    end
+  end
+end


### PR DESCRIPTION
`CachingUpdater` keeps a download on disk so an interrupted update can be resumed, and works out where it got to from the size of the partial file. A part that was half written when the power went out, or that arrived corrupted, is therefore treated as good, and only surfaces much later as an fwup error.

`NervesHubLink.UpdateManager.PartsUpdater` hashes each part as it arrives and compares it to the `partials_checksums` NervesHub sends in the update payload:

* a part that fails is downloaded again, without discarding the parts before it
* a part already downloaded and verified is not fetched again after a restart
* the firmware handed to fwup is known to match what NervesHub sent

The verified parts are streamed into fwup in order, so the firmware never has to be on disk twice. They're kept afterwards and removed when a different firmware starts downloading, so an update that applies but doesn't stick doesn't have to be downloaded again.

```elixir
config :nerves_hub_link,
  updater: NervesHubLink.UpdateManager.PartsUpdater

config :nerves_hub_link, NervesHubLink.UpdateManager.PartsUpdater,
  cache_dir: "/data/nerves_hub_link/firmware",
  part_size: 1_048_576,
  max_part_attempts: 3,
  max_concurrent_parts: 1
```

## Downloading parts in parallel

`max_concurrent_parts` above `1` divides the parts still needed into that many contiguous ranges and fetches each over its own connection. That helps on links where a single connection can't fill the available bandwidth. Ranges, rather than one connection per part, so a 60 MB firmware doesn't become 60 requests.

It defaults to `1`, which behaves exactly as a single whole-file download; there's a test asserting the request count so that can't silently regress. The resume scan checks every part rather than stopping at the first gap, so ranges that finished out of order are all kept.

It costs a connection per range on the device *and* on whatever serves the firmware, multiplied across a deployment, so it stays off by default. Each connection also reports its own `:started` status, so NervesHub sees one per range.

## Supporting changes

* `Message.UpdateInfo` carries the `size`, `checksum` and `partials_checksums` the server already sends. They were being dropped while parsing.
* `Downloader` takes `:range_end`, pairing with `:resume_from_bytes` to fetch one slice of a file, and `:label`, which names a download in every line it logs so concurrent ones can be told apart.
* `Updater` gains an optional `handle_message/2` callback for messages an updater sends itself, and for exits it needs to see. Feeding fwup can't happen inside a downloader callback, which the downloader blocks on with a 60 second timeout.

## Fixes found along the way

* A resumed download asked for the wrong byte range after a disconnect. The retry offset was measured from the interrupted request instead of from the file, so the bytes that came back were appended in the wrong place. This silently corrupts `CachingUpdater` resumes today. Regression test included, which fails without the fix.
* `Updater` ignored the `{:stop, reason, state}` return its own callback documents, raising `CaseClauseError` instead of stopping.
* The downloader wrote credentials to the log. Firmware URLs are signed, so the query string is one, and it was written when resuming or following a redirect. It was also reported in the crash report OTP writes when a download stops abnormally, along with anything configured as SSL options, which can include a private key. `format_status/1` now takes those out and leaves the rest, which is what makes the report useful.

## Notes for review

* `part_size` has to match the 1 MiB NervesHub hashes with. A value implying a different part count is rejected and falls back to a single verified download. `nerves_hub_web` uses a hardcoded `1_048_576` part size.
* Older servers don't send `partials_checksums`. Those fall back to a single download verified against the whole-file `checksum`, with a warning. That is the same guarantee `CachingUpdater` gives.
