### PR TITLE
Refuse firmware and archives that cannot be signature verified

### DIFF
--- a/lib/nerves_hub_link/archive_manager.ex
+++ b/lib/nerves_hub_link/archive_manager.ex
@@ -20,6 +20,7 @@ defmodule NervesHubLink.ArchiveManager do
 
   alias NervesHubLink.Client
   alias NervesHubLink.Downloader
+  alias NervesHubLink.FwupConfig
   alias NervesHubLink.Message.ArchiveInfo
 
   require Logger
@@ -170,6 +171,20 @@ defmodule NervesHubLink.ArchiveManager do
   end
 
   defp maybe_update_archive(info, verification_keys, state) do
+    if FwupConfig.signing_keys_available?(verification_keys) do
+      download_archive(info, verification_keys, state)
+    else
+      # `fwup -V` exits 0 when it is given no public key, so an unsigned archive
+      # would validate. Refuse the archive rather than hand it to the client.
+      Logger.error(
+        "[NervesHubLink] Refusing archive : no public keys are available to verify the archive signature"
+      )
+
+      state
+    end
+  end
+
+  defp download_archive(info, verification_keys, state) do
     # Cancel an existing timer if it exists.
     # This prevents rescheduled updates`
     # from compounding.
@@ -226,6 +241,14 @@ defmodule NervesHubLink.ArchiveManager do
   end
 
   defp valid_archive?(file_path, public_keys) do
+    if FwupConfig.signing_keys_available?(public_keys) do
+      fwup_verify(file_path, public_keys)
+    else
+      false
+    end
+  end
+
+  defp fwup_verify(file_path, public_keys) do
     args = ["-V", "-i", file_path]
 
     args =

--- a/lib/nerves_hub_link/fwup_config.ex
+++ b/lib/nerves_hub_link/fwup_config.ex
@@ -23,6 +23,22 @@ defmodule NervesHubLink.FwupConfig do
           fwup_env: [{String.t(), String.t()}]
         }
 
+  @doc """
+  Returns true when at least one usable public key is available to verify a
+  firmware or archive signature.
+
+  `fwup` only verifies a signature when it is given at least one `--public-key`,
+  so an empty list means an image would be applied unverified. Non-binary
+  entries are ignored, matching the filtering done in
+  `NervesHubLink.Configurator`, so that a malformed key list cannot stand in for
+  a real one.
+  """
+  @spec signing_keys_available?([binary()]) :: boolean()
+  def signing_keys_available?(public_keys) when is_list(public_keys),
+    do: Enum.any?(public_keys, &is_binary/1)
+
+  def signing_keys_available?(_public_keys), do: false
+
   @doc "Raises an ArgumentError on invalid arguments"
   @spec validate!(t()) :: t()
   def validate!(%__MODULE__{} = args) do

--- a/lib/nerves_hub_link/socket.ex
+++ b/lib/nerves_hub_link/socket.ex
@@ -19,6 +19,7 @@ defmodule NervesHubLink.Socket do
   alias NervesHubLink.Configurator
   alias NervesHubLink.Configurator.SharedSecret
   alias NervesHubLink.Extensions
+  alias NervesHubLink.FwupConfig
   alias NervesHubLink.Message.ArchiveInfo
   alias NervesHubLink.Message.UpdateInfo
   alias NervesHubLink.NetworkInterface
@@ -351,37 +352,25 @@ defmodule NervesHubLink.Socket do
   # Device API messages
   #
   def handle_message(@device_topic, "fwup_public_keys", params, socket) do
-    count = Enum.count(params["keys"])
-
-    config = %{socket.assigns.config | fwup_public_keys: params["keys"]}
-
-    if count == 0 do
-      Logger.warning(
-        "[NervesHubLink] No public keys for firmware verification received : firmware updates cannot be verified and installed"
+    config =
+      update_public_keys(
+        socket.assigns.config,
+        :fwup_public_keys,
+        params["keys"],
+        "firmware"
       )
-    else
-      Logger.info(
-        "[NervesHubLink] Public keys for firmware verification updated - #{count} key(s) received"
-      )
-    end
 
     {:ok, assign(socket, config: config)}
   end
 
   def handle_message(@device_topic, "archive_public_keys", params, socket) do
-    count = Enum.count(params["keys"])
-
-    config = %{socket.assigns.config | archive_public_keys: params["keys"]}
-
-    if count == 0 do
-      Logger.warning(
-        "[NervesHubLink] No public keys for archive verification received : archive updates cannot be verified and installed"
+    config =
+      update_public_keys(
+        socket.assigns.config,
+        :archive_public_keys,
+        params["keys"],
+        "archive"
       )
-    else
-      Logger.info(
-        "[NervesHubLink] Public keys for archive verification updated - #{count} key(s) received"
-      )
-    end
 
     {:ok, assign(socket, config: config)}
   end
@@ -791,6 +780,42 @@ defmodule NervesHubLink.Socket do
       end
 
     merge_http_opts(base, config.socket[:http_opts] || [])
+  end
+
+  # NervesHub distributes signing keys over the socket, but it also supplies the
+  # firmware those keys verify. Letting it replace a locally configured key list
+  # with an empty one would let the server turn off signature verification, so
+  # an empty list never clears keys we already hold.
+  @spec update_public_keys(Configurator.Config.t(), atom(), any(), String.t()) ::
+          Configurator.Config.t()
+  defp update_public_keys(config, field, received_keys, label) do
+    received_keys =
+      if is_list(received_keys), do: Enum.filter(received_keys, &is_binary/1), else: []
+
+    existing_keys = Map.fetch!(config, field)
+
+    cond do
+      received_keys != [] ->
+        Logger.info(
+          "[NervesHubLink] Public keys for #{label} verification updated - #{length(received_keys)} key(s) received"
+        )
+
+        Map.put(config, field, received_keys)
+
+      FwupConfig.signing_keys_available?(existing_keys) ->
+        Logger.error(
+          "[NervesHubLink] NervesHub sent no public keys for #{label} verification : keeping the #{length(existing_keys)} locally configured key(s)"
+        )
+
+        config
+
+      true ->
+        Logger.error(
+          "[NervesHubLink] No public keys for #{label} verification are available : #{label} updates will be refused"
+        )
+
+        config
+    end
   end
 
   # Shallow-merge user-supplied opts on top of the base, but for :transport_opts

--- a/lib/nerves_hub_link/update_manager.ex
+++ b/lib/nerves_hub_link/update_manager.ex
@@ -202,6 +202,25 @@ defmodule NervesHubLink.UpdateManager do
   end
 
   defp maybe_update_firmware(%UpdateInfo{} = update_info, fwup_public_keys, %State{} = state) do
+    if FwupConfig.signing_keys_available?(fwup_public_keys) do
+      update_firmware(update_info, fwup_public_keys, state)
+    else
+      # Without a public key `fwup` applies the firmware without checking its
+      # signature, so refuse the update rather than install an unverified image.
+      Logger.error(
+        "[NervesHubLink:UpdateManager] Refusing firmware update : no public keys are available to verify the firmware signature"
+      )
+
+      NervesHubLink.send_update_status(
+        {:failed, "Refusing unverified firmware : no public keys available"}
+      )
+
+      state
+    end
+  end
+
+  @spec update_firmware(UpdateInfo.t(), [binary()], State.t()) :: State.t()
+  defp update_firmware(%UpdateInfo{} = update_info, fwup_public_keys, %State{} = state) do
     NervesHubLink.send_update_status(:received)
 
     case Client.update_available(update_info) do

--- a/mix.exs
+++ b/mix.exs
@@ -23,10 +23,6 @@ defmodule NervesHubLink.MixProject do
 
   def application do
     [
-      env: [
-        host: nil,
-        fwup_public_keys: []
-      ],
       extra_applications: [:logger, :iex, :inets, :sasl, :os_mon],
       mod: {NervesHubLink.Application, []}
     ]

--- a/test/nerves_hub_link/archive_manager_test.exs
+++ b/test/nerves_hub_link/archive_manager_test.exs
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Josh Kalderimis
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesHubLink.ArchiveManagerTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias NervesHubLink.ArchiveManager
+  alias NervesHubLink.ClientMock
+  alias NervesHubLink.Message.ArchiveInfo
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup do
+    stub_with(ClientMock, NervesHubLink.ClientStub)
+
+    data_path = Path.join(System.tmp_dir!(), "archive_manager_test_#{System.unique_integer()}")
+    File.mkdir_p!(data_path)
+    on_exit(fn -> File.rm_rf(data_path) end)
+
+    manager =
+      start_supervised!(%{
+        id: ArchiveManager,
+        start: {ArchiveManager, :start_link, [%{data_path: data_path}]}
+      })
+
+    {:ok, manager: manager, archive_info: archive_info()}
+  end
+
+  describe "refusing archives that cannot be verified" do
+    test "an archive is refused when no public keys are available", context do
+      # `fwup -V` exits 0 when given no public key, so an unsigned archive would
+      # otherwise validate successfully. Answering `:download` here makes the
+      # manager report `:downloading` unless the archive is refused first.
+      stub(ClientMock, :archive_available, fn _ -> :download end)
+
+      assert ArchiveManager.apply_archive(context.manager, context.archive_info, []) == :idle
+      assert ArchiveManager.currently_downloading_uuid(context.manager) == nil
+    end
+
+    test "a refused archive is never offered to the client", context do
+      expect(ClientMock, :archive_available, 0, fn _ -> :download end)
+
+      assert ArchiveManager.apply_archive(context.manager, context.archive_info, []) == :idle
+    end
+
+    test "keys that are not binaries do not count as public keys", context do
+      expect(ClientMock, :archive_available, 0, fn _ -> :download end)
+
+      assert ArchiveManager.apply_archive(context.manager, context.archive_info, [nil, :key]) ==
+               :idle
+    end
+
+    test "a refused archive leaves the manager usable", context do
+      expect(ClientMock, :archive_available, fn _ -> :ignore end)
+
+      assert ArchiveManager.apply_archive(context.manager, context.archive_info, []) == :idle
+
+      assert ArchiveManager.apply_archive(context.manager, context.archive_info, ["a key"]) ==
+               :idle
+
+      assert ArchiveManager.currently_downloading_uuid(context.manager) == nil
+    end
+  end
+
+  defp archive_info() do
+    %ArchiveInfo{
+      architecture: "arm",
+      description: "test archive",
+      platform: "rpi0",
+      size: 1024,
+      url: "http://localhost/test.fw",
+      uuid: "6f1f9d4a-1b3e-4c9a-9a1e-3c9d5f2b7a10",
+      version: "1.0.0"
+    }
+  end
+end

--- a/test/nerves_hub_link/socket_messages_test.exs
+++ b/test/nerves_hub_link/socket_messages_test.exs
@@ -143,6 +143,38 @@ defmodule NervesHubLink.SocketMessagesTest do
              ]
     end
 
+    test "an empty key list from the server does not clear the configured firmware keys", %{
+      socket: socket
+    } do
+      # NervesHub supplies the firmware as well as the keys that verify it, so a
+      # server that sends no keys must not be able to disable signature checking.
+      push(socket, @device_topic, "fwup_public_keys", %{"keys" => []})
+
+      assert NervesHubLink.socket_connected?(socket)
+
+      assert :sys.get_state(socket).assigns.config.fwup_public_keys == ["configured fwup key"]
+    end
+
+    test "an empty key list from the server does not clear the configured archive keys", %{
+      socket: socket
+    } do
+      push(socket, @device_topic, "archive_public_keys", %{"keys" => []})
+
+      assert NervesHubLink.socket_connected?(socket)
+
+      assert :sys.get_state(socket).assigns.config.archive_public_keys == [
+               "configured archive key"
+             ]
+    end
+
+    test "keys from the server that are not binaries are discarded", %{socket: socket} do
+      push(socket, @device_topic, "fwup_public_keys", %{"keys" => [nil, 42]})
+
+      assert NervesHubLink.socket_connected?(socket)
+
+      assert :sys.get_state(socket).assigns.config.fwup_public_keys == ["configured fwup key"]
+    end
+
     test "an extensions:get message asks to join the extensions topic", %{socket: socket} do
       push(socket, @device_topic, "extensions:get", %{})
 

--- a/test/nerves_hub_link/update_manager_test.exs
+++ b/test/nerves_hub_link/update_manager_test.exs
@@ -47,6 +47,11 @@ defmodule NervesHubLink.UpdateManagerTest do
 
   @update_alarm NervesHubLink.UpdateInProgress
 
+  # The updater is faked in these tests, so this key never verifies anything.
+  # It only needs to be present, because `UpdateManager` refuses an update when
+  # no public key is available to check the firmware signature.
+  @public_keys ["dGVzdC1wdWJsaWMta2V5"]
+
   setup :set_mox_global
   setup :verify_on_exit!
   setup :reset_update_alarm
@@ -83,7 +88,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       {:ok, manager} = UpdateManager.start_link({fwup_config, updater})
 
-      assert UpdateManager.apply_update(manager, update_payload, []) == :updating
+      assert UpdateManager.apply_update(manager, update_payload, @public_keys) == :updating
 
       assert GenServer.stop(manager) == :ok
     end
@@ -97,9 +102,55 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       {:ok, manager} = UpdateManager.start_link({fwup_config, updater})
 
-      assert UpdateManager.apply_update(manager, update_payload, []) == :idle
+      assert UpdateManager.apply_update(manager, update_payload, @public_keys) == :idle
 
       assert GenServer.stop(manager) == :ok
+    end
+  end
+
+  describe "refusing firmware that cannot be verified" do
+    setup [:stub_client, :watch_socket]
+
+    test "an update is refused when no public keys are available", context do
+      manager = start_manager()
+
+      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      assert_receive {:update_status, {:failed, reason}}
+      assert reason =~ "Refusing unverified firmware"
+    end
+
+    test "a refused update is never offered to the client", context do
+      # `fwup` skips signature checking entirely when it is given no public key,
+      # so the update has to be dropped before the client can answer `:apply`.
+      manager = start_manager()
+
+      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      refute_receive {:update_status, :received}
+    end
+
+    test "a refused update does not raise the update alarm", context do
+      manager = start_manager()
+
+      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      refute alarm_set?(@update_alarm)
+    end
+
+    test "keys that are not binaries do not count as public keys", context do
+      manager = start_manager()
+
+      assert UpdateManager.apply_update(manager, context.update_info, [nil, :key]) == :idle
+      assert_receive {:update_status, {:failed, reason}}
+      assert reason =~ "Refusing unverified firmware"
+    end
+
+    test "the manager stays usable after refusing an update", context do
+      stub(ClientMock, :update_available, fn _ -> :apply end)
+      stub(UpdaterMock, :start_update, fn _, _, _ -> {:ok, spawn(fn -> :ok end)} end)
+
+      manager = start_manager()
+
+      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      assert UpdateManager.apply_update(manager, context.update_info, @public_keys) == :updating
     end
   end
 
@@ -111,7 +162,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       manager = start_manager()
 
-      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      assert UpdateManager.apply_update(manager, context.update_info, @public_keys) == :idle
       assert_receive {:update_status, {:ignored, ""}}
       refute alarm_set?(@update_alarm)
     end
@@ -121,7 +172,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       manager = start_manager()
 
-      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      assert UpdateManager.apply_update(manager, context.update_info, @public_keys) == :idle
       assert_receive {:update_status, {:ignored, "on battery"}}
     end
 
@@ -130,7 +181,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       manager = start_manager()
 
-      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      assert UpdateManager.apply_update(manager, context.update_info, @public_keys) == :idle
       assert_receive {:update_status, {:reschedule, 10}}
     end
 
@@ -139,7 +190,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       manager = start_manager()
 
-      assert UpdateManager.apply_update(manager, context.update_info, []) == :idle
+      assert UpdateManager.apply_update(manager, context.update_info, @public_keys) == :idle
       assert_receive {:update_status, {:reschedule, 5}}
     end
   end
@@ -163,7 +214,8 @@ defmodule NervesHubLink.UpdateManagerTest do
     test "a duplicate update message doesn't restart the update", context do
       # start_update/1 is stubbed to be called exactly once, so a second call
       # would be an unexpected call and fail verification on exit
-      assert UpdateManager.apply_update(context.manager, context.update_info, []) == :updating
+      assert UpdateManager.apply_update(context.manager, context.update_info, @public_keys) ==
+               :updating
 
       assert UpdateManager.currently_downloading_uuid(context.manager) ==
                context.update_info.firmware_meta.uuid
@@ -246,7 +298,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
       # UpdaterMock has no expectations, so an update started by it would fail
       # verification. Only AlternateUpdater should be asked to start the update.
-      assert UpdateManager.apply_update(manager, context.update_info, []) == :updating
+      assert UpdateManager.apply_update(manager, context.update_info, @public_keys) == :updating
     end
   end
 
@@ -281,7 +333,7 @@ defmodule NervesHubLink.UpdateManagerTest do
 
     update_info = update_info()
 
-    assert UpdateManager.apply_update(manager, update_info, []) == :updating
+    assert UpdateManager.apply_update(manager, update_info, @public_keys) == :updating
 
     # Confirms the precondition for the tests that assert the alarm is cleared
     assert alarm_eventually_set?(@update_alarm)


### PR DESCRIPTION
## The problem

`fwup` only verifies a signature when it is given at least one `--public-key`. Both updaters and the archive manager build that argv with `Enum.reduce(public_keys, args, ...)`, so an **empty key list added no `--public-key` at all** and the image was applied unverified. `fwup -V -i` likewise exits 0 when given no keys, so `valid_archive?/2` returned `true` for an unsigned archive.

The empty list was reachable by default, not just through misconfiguration:

1. `fwup_public_keys` defaults to `[]`.
2. `Configurator.add_fwup_public_keys/1` does not treat empty as an error — it leaves the list empty and asks the server for keys `"on_connect"`.
3. `Socket.handle_message/4` then assigned whatever the server sent back, **including `[]`**.
4. `fwup --apply` ran with no `--public-key`.

The existing log line made this hard to notice — it warned that firmware *"cannot be verified and installed"*, while the firmware was in fact installed.

## The fix

Fail closed rather than silently skipping verification.

- **`FwupConfig.signing_keys_available?/1`** — one definition of "is a usable key present", so the firmware and archive paths cannot drift apart. Non-binary entries do not count, so a malformed list (e.g. `[nil]`) cannot stand in for a real key.
- **`UpdateManager`** — refuses the update and reports `{:failed, ...}` to NervesHub so the refusal is visible in the UI rather than the device just going quiet. The check runs *before* `Client.update_available/1`, so the client is never asked to approve firmware that could not be verified.
- **`ArchiveManager`** — same refusal, and `valid_archive?/2` returns `false` when no key is available instead of shelling out to `fwup -V` and trusting its exit code.
- **`Socket`** — an empty key list from the server no longer clears locally configured keys.

## ⚠️ Breaking change

A device that has **no keys configured and receives none from NervesHub** will now refuse updates, where previously it applied them unverified. That is the intent, but the failure mode is "fleet stops accepting updates", so this wants a version bump that signals it and a CHANGELOG entry at release time (this repo only touches `CHANGELOG.md` on release, so none is included here).

## Also included

`mix.exs` — removal of the `env: [host: nil, fwup_public_keys: []]` block as it was unused.